### PR TITLE
Make Transform Handle movable even if Input.simulateMouseWithTouches disabled

### DIFF
--- a/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionAxis.cs
+++ b/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionAxis.cs
@@ -1,4 +1,4 @@
-﻿using TransformHandles.Utils;
+using TransformHandles.Utils;
 using UnityEngine;
 
 namespace TransformHandles
@@ -39,7 +39,8 @@ namespace TransformHandles
 
         public override void Interact(Vector3 pPreviousPosition)
         {
-            var cameraRay = _handleCamera.ScreenPointToRay(Input.mousePosition);
+
+            var cameraRay = _handleCamera.ScreenPointToRay(getPos());
 
             var closestT = MathUtils.ClosestPointOnRay(_rAxisRay, cameraRay);
             var hitPoint = _rAxisRay.GetPoint(closestT);
@@ -66,7 +67,13 @@ namespace TransformHandles
 
             base.Interact(pPreviousPosition);
         }
-        
+        private Vector3 getPos() {
+            if (Input.touchCount > 0) {
+                return Input.GetTouch(0).position;
+            } else {
+                return Input.mousePosition;
+            }
+        }
         public override void StartInteraction(Vector3 pHitPoint)
         {
             base.StartInteraction(pHitPoint);
@@ -79,7 +86,7 @@ namespace TransformHandles
             
             _rAxisRay = new Ray(_startPosition, rAxis);
 
-            var cameraRay = _handleCamera.ScreenPointToRay(Input.mousePosition);
+            var cameraRay = _handleCamera.ScreenPointToRay(getPos());
 
             var closestT = MathUtils.ClosestPointOnRay(_rAxisRay, cameraRay);
             var hitPoint = _rAxisRay.GetPoint(closestT);

--- a/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionPlane.cs
+++ b/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionPlane.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace TransformHandles
 {
@@ -38,7 +38,7 @@ namespace TransformHandles
 
         public override void Interact(Vector3 pPreviousPosition)
         {
-            var ray = _handleCamera.ScreenPointToRay(Input.mousePosition);
+            var ray = _handleCamera.ScreenPointToRay(getPos());
 
             _plane.Raycast(ray, out var d);
             
@@ -70,6 +70,13 @@ namespace TransformHandles
 
             base.Interact(pPreviousPosition);
         }
+        private Vector3 getPos() {
+            if (Input.touchCount > 0) {
+                return Input.GetTouch(0).position;
+            } else {
+                return Input.mousePosition;
+            }
+        }
 
         public override void StartInteraction(Vector3 pHitPoint)
         {
@@ -80,7 +87,7 @@ namespace TransformHandles
             var position = ParentHandle.target.position;
             _plane = new Plane(rPerp, position);
             
-            var ray = _handleCamera.ScreenPointToRay(Input.mousePosition);
+            var ray = _handleCamera.ScreenPointToRay(getPos());
 
             _plane.Raycast(ray, out var d);
             

--- a/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Rotation/RotationAxis.cs
+++ b/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Rotation/RotationAxis.cs
@@ -1,4 +1,4 @@
-﻿using TransformHandles.Utils;
+using TransformHandles.Utils;
 using UnityEngine;
 
 namespace TransformHandles
@@ -33,9 +33,18 @@ namespace TransformHandles
             _rotationHandleTransform = transform.GetComponentInParent<Handle>().transform;
         }
 
+        private Vector3 getPos() {
+            if (Input.touchCount > 0) {
+                return Input.GetTouch(0).position;
+            } else {
+                return Input.mousePosition;
+            }
+        }
+
         public override void Interact(Vector3 pPreviousPosition)
         {
-            var cameraRay = _handleCamera.ScreenPointToRay(Input.mousePosition);
+            
+            var cameraRay = _handleCamera.ScreenPointToRay(getPos());
             
             if (!_axisPlane.Raycast(cameraRay, out var hitT))
             {

--- a/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Rotation/RotationAxis.cs
+++ b/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Rotation/RotationAxis.cs
@@ -100,7 +100,7 @@ namespace TransformHandles
 
             _axisPlane = new Plane(_rotatedAxis, ParentHandle.target.position);
 
-            var     cameraRay = _handleCamera.ScreenPointToRay(Input.mousePosition);
+            var     cameraRay = _handleCamera.ScreenPointToRay(getPos());
             var startHitPoint = _axisPlane.Raycast(cameraRay, out var hitT) ?
                 cameraRay.GetPoint(hitT) : _axisPlane.ClosestPointOnPlane(pHitPoint);
             

--- a/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleAxis.cs
+++ b/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleAxis.cs
@@ -1,4 +1,4 @@
-﻿using TransformHandles.Utils;
+using TransformHandles.Utils;
 using UnityEngine;
 
 namespace TransformHandles
@@ -34,9 +34,18 @@ namespace TransformHandles
             cubeMeshRenderer.transform.localPosition = _axis * (Size * (1 + delta));
         }
 
+        private Vector3 getPos() {
+            if (Input.touchCount > 0) {
+                return Input.GetTouch(0).position;
+            } else {
+                return Input.mousePosition;
+            }
+        }
+
+
         public override void Interact(Vector3 pPreviousPosition)
         {
-            var cameraRay = _handleCamera.ScreenPointToRay(Input.mousePosition);
+            var cameraRay = _handleCamera.ScreenPointToRay(getPos());
 
             var   closestT = MathUtils.ClosestPointOnRay(_rAxisRay, cameraRay);
             var hitPoint = _rAxisRay.GetPoint(closestT);
@@ -79,7 +88,7 @@ namespace TransformHandles
             var position = ParentHandle.target.position;
             _rAxisRay = new Ray(position, rAxis);
             
-            var cameraRay = _handleCamera.ScreenPointToRay(Input.mousePosition);
+            var cameraRay = _handleCamera.ScreenPointToRay(getPos());
             
             var   closestT = MathUtils.ClosestPointOnRay(_rAxisRay, cameraRay);
             var hitPoint = _rAxisRay.GetPoint(closestT);

--- a/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleGlobal.cs
+++ b/Packages/runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleGlobal.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace TransformHandles
 {
@@ -17,9 +17,18 @@ namespace TransformHandles
             DefaultColor = defaultColor;
         }
 
+        private Vector3 getPos() {
+            if (Input.touchCount > 0) {
+                return Input.GetTouch(0).position;
+            } else {
+                return Input.mousePosition;
+            }
+        }
+
+
         public override void Interact(Vector3 pPreviousPosition)
         {
-            var mouseVector = (Input.mousePosition - pPreviousPosition);
+            var mouseVector = (getPos() - pPreviousPosition);
             var d = (mouseVector.x + mouseVector.y) * Time.deltaTime * 2;
             delta += d;
             ParentHandle.target.localScale = _startScale + Vector3.Scale(_startScale,_axis) * delta;

--- a/Packages/runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
+++ b/Packages/runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
@@ -210,6 +210,15 @@ namespace TransformHandles
             MouseInput();
             KeyboardInput();
         }
+
+        private Vector3 getPos() {
+            if (Input.touchCount > 0) {
+                return Input.GetTouch(0).position;
+            } else {
+                return Input.mousePosition;
+            }
+        }
+
         
         protected virtual void GetHandle(ref HandleBase handle, ref Vector3 hitPoint)
         {
@@ -218,7 +227,7 @@ namespace TransformHandles
             var size = 0;
             try
             {
-                var ray = mainCamera.ScreenPointToRay(Input.mousePosition);
+                var ray = mainCamera.ScreenPointToRay(getPos());
                 size = Physics.RaycastNonAlloc(ray, _rayHits, 1000, layerMask);
             }
             catch (MissingReferenceException)

--- a/Packages/runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
+++ b/Packages/runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
@@ -81,7 +81,7 @@ namespace TransformHandles
         {
             if (_transformHashSet.Contains(target)) { Debug.LogWarning($"{target} already has a handle."); return null; }
             
-            var ghost = Instantiate(ghostPrefab).GetComponent<Ghost>();
+            var ghost = CreateGhost();
             ghost.Initialize();
 
             var transformHandle = Instantiate(transformHandlePrefab).GetComponent<Handle>();
@@ -99,12 +99,29 @@ namespace TransformHandles
             
             return transformHandle;
         }
+
+        private Ghost CreateGhost()
+        {
+            Ghost ghost;
+            
+            if (ghostPrefab == null)
+            {
+                var ghostObject = new GameObject();
+                ghost = ghostObject.AddComponent<Ghost>();
+            }
+            else
+            {
+                ghost = Instantiate(ghostPrefab).GetComponent<Ghost>();
+            }
+            
+            return ghost;
+        }
         
         public Handle CreateHandleFromList(List<Transform> targets)
         {
             if(targets.Count == 0) { Debug.LogWarning("List is empty."); return null; }
             
-            var ghost = Instantiate(ghostPrefab).GetComponent<Ghost>();
+            var ghost = CreateGhost();
             ghost.Initialize();
 
             var transformHandle = Instantiate(transformHandlePrefab).GetComponent<Handle>();


### PR DESCRIPTION

Add getPos() and GetMouseButton(Up, Down)Expl(), so if a mouse click or movement is recognized, it will use that, else fallback to touch.


I'm making an open-source cross-platform Unity game, which needed keyboard, mouse, and touch support. The way we achieved that is to disable simulateMouseWithTouches, but that made this package unusable. So I of course forked this repository, then modified it to account for that.