### PR TITLE
fix: ChangeAxes now re-applies the handle mask (closes #10)

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionAxis.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionAxis.cs
@@ -45,8 +45,10 @@ namespace TransformHandles
             _coneTransform = _coneGameObject.transform;
             _cameraTransform = _handleCamera.transform;
 
-            _coneMaterial = coneMeshRenderer.material;
-            _lineMaterial = lineMeshRenderer.material;
+            // Instantiate materials once; Initialize is re-runnable via Handle.ChangeAxes
+            // and MeshRenderer.material allocates a new instance on every access.
+            if (_coneMaterial == null) _coneMaterial = coneMeshRenderer.material;
+            if (_lineMaterial == null) _lineMaterial = lineMeshRenderer.material;
 
             _axis = _coneTransform.up;
             DefaultColor = defaultColor;

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionHandle.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionHandle.cs
@@ -17,55 +17,46 @@ namespace TransformHandles
 
         private Handle _parentHandle;
 
-        private bool _handleInitialized;
-
         /// <summary>
         /// Initializes the position handle with all its axes and planes.
+        /// Re-runnable so <see cref="Handle.ChangeAxes"/> can filter visible axes/planes after creation.
         /// </summary>
         /// <param name="handle">The parent handle.</param>
         public void Initialize(Handle handle)
         {
-            if (_handleInitialized) return;
-
             _parentHandle = handle;
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.X))
-            {
-                xAxis.gameObject.SetActive(true);
-                xAxis.Initialize(handle);
-            }
+            // Planes ship as children of their corresponding axis GameObjects in the prefab.
+            // Reparent them onto this handle so masking an axis off doesn't also hide the plane.
+            if (xPlane.transform.parent != transform) xPlane.transform.SetParent(transform, true);
+            if (yPlane.transform.parent != transform) yPlane.transform.SetParent(transform, true);
+            if (zPlane.transform.parent != transform) zPlane.transform.SetParent(transform, true);
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.Y))
-            {
-                yAxis.gameObject.SetActive(true);
-                yAxis.Initialize(handle);
-            }
+            var hasX = handle.axes.HasAxis(HandleAxes.X);
+            var hasY = handle.axes.HasAxis(HandleAxes.Y);
+            var hasZ = handle.axes.HasAxis(HandleAxes.Z);
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.Z))
-            {
-                zAxis.gameObject.SetActive(true);
-                zAxis.Initialize(handle);
-            }
+            xAxis.gameObject.SetActive(hasX);
+            if (hasX) xAxis.Initialize(handle);
 
-            if (_parentHandle.axes.HasBothAxes(HandleAxes.X, HandleAxes.Y))
-            {
-                zPlane.gameObject.SetActive(true);
-                zPlane.Initialize(_parentHandle, Vector3.forward, Vector3.up, -Vector3.right);
-            }
+            yAxis.gameObject.SetActive(hasY);
+            if (hasY) yAxis.Initialize(handle);
 
-            if (_parentHandle.axes.HasBothAxes(HandleAxes.Y, HandleAxes.Z))
-            {
-                xPlane.gameObject.SetActive(true);
-                xPlane.Initialize(_parentHandle, Vector3.right, Vector3.forward, Vector3.up);
-            }
+            zAxis.gameObject.SetActive(hasZ);
+            if (hasZ) zAxis.Initialize(handle);
 
-            if (_parentHandle.axes.HasBothAxes(HandleAxes.X, HandleAxes.Z))
-            {
-                yPlane.gameObject.SetActive(true);
-                yPlane.Initialize(_parentHandle, Vector3.right, Vector3.up, Vector3.forward);
-            }
+            var hasXY = handle.axes.HasBothAxes(HandleAxes.X, HandleAxes.Y);
+            var hasYZ = handle.axes.HasBothAxes(HandleAxes.Y, HandleAxes.Z);
+            var hasXZ = handle.axes.HasBothAxes(HandleAxes.X, HandleAxes.Z);
 
-            _handleInitialized = true;
+            zPlane.gameObject.SetActive(hasXY);
+            if (hasXY) zPlane.Initialize(handle, Vector3.forward, Vector3.up, -Vector3.right);
+
+            xPlane.gameObject.SetActive(hasYZ);
+            if (hasYZ) xPlane.Initialize(handle, Vector3.right, Vector3.forward, Vector3.up);
+
+            yPlane.gameObject.SetActive(hasXZ);
+            if (hasXZ) yPlane.Initialize(handle, Vector3.right, Vector3.up, Vector3.forward);
         }
     }
 }

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionPlane.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionPlane.cs
@@ -48,7 +48,10 @@ namespace TransformHandles
 
             _quadGameObject = quadMeshRenderer.gameObject;
             _cameraTransform = _handleCamera.transform;
-            _quadMaterial = quadMeshRenderer.material;
+
+            // Instantiate the material once; Initialize is re-runnable via Handle.ChangeAxes
+            // and MeshRenderer.material allocates a new instance on every access.
+            if (_quadMaterial == null) _quadMaterial = quadMeshRenderer.material;
 
             _quadGameObject.transform.localPosition = (_axis1 + _axis2) * PlaneVisualOffset;
         }

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Rotation/RotationAxis.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Rotation/RotationAxis.cs
@@ -40,7 +40,10 @@ namespace TransformHandles
             _handleCamera = ParentHandle.handleCamera;
 
             _rotationHandleTransform = transform.GetComponentInParent<Handle>().transform;
-            _torusMaterial = torusMeshRenderer.material;
+
+            // Instantiate the material once; Initialize is re-runnable via Handle.ChangeAxes
+            // and MeshRenderer.material allocates a new instance on every access.
+            if (_torusMaterial == null) _torusMaterial = torusMeshRenderer.material;
         }
 
         /// <inheritdoc/>

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Rotation/RotationHandle.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Rotation/RotationHandle.cs
@@ -13,38 +13,28 @@ namespace TransformHandles
 
         private Handle _parentHandle;
 
-        private bool _handleInitialized;
-
         /// <summary>
         /// Initializes the rotation handle with all its axes.
+        /// Re-runnable so <see cref="Handle.ChangeAxes"/> can filter visible rings after creation.
         /// </summary>
         /// <param name="handle">The parent handle.</param>
         public void Initialize(Handle handle)
         {
-            if (_handleInitialized) return;
-
             _parentHandle = handle;
             transform.SetParent(_parentHandle.transform, false);
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.X))
-            {
-                xAxis.gameObject.SetActive(true);
-                xAxis.Initialize(_parentHandle, Vector3.right);
-            }
+            var hasX = handle.axes.HasAxis(HandleAxes.X);
+            var hasY = handle.axes.HasAxis(HandleAxes.Y);
+            var hasZ = handle.axes.HasAxis(HandleAxes.Z);
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.Y))
-            {
-                yAxis.gameObject.SetActive(true);
-                yAxis.Initialize(_parentHandle, Vector3.up);
-            }
+            xAxis.gameObject.SetActive(hasX);
+            if (hasX) xAxis.Initialize(handle, Vector3.right);
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.Z))
-            {
-                zAxis.gameObject.SetActive(true);
-                zAxis.Initialize(_parentHandle, Vector3.forward);
-            }
+            yAxis.gameObject.SetActive(hasY);
+            if (hasY) yAxis.Initialize(handle, Vector3.up);
 
-            _handleInitialized = true;
+            zAxis.gameObject.SetActive(hasZ);
+            if (hasZ) zAxis.Initialize(handle, Vector3.forward);
         }
     }
 }

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleAxis.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleAxis.cs
@@ -38,8 +38,10 @@ namespace TransformHandles
 
             _handleCamera = ParentHandle.handleCamera;
 
-            _cubeMaterial = cubeMeshRenderer.material;
-            _lineMaterial = lineMeshRenderer.material;
+            // Instantiate materials once; Initialize is re-runnable via Handle.ChangeAxes
+            // and MeshRenderer.material allocates a new instance on every access.
+            if (_cubeMaterial == null) _cubeMaterial = cubeMeshRenderer.material;
+            if (_lineMaterial == null) _lineMaterial = lineMeshRenderer.material;
         }
 
         protected void Update()

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleGlobal.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleGlobal.cs
@@ -27,7 +27,10 @@ namespace TransformHandles
             ParentHandle = handle;
             _axis = axis;
             DefaultColor = defaultColor;
-            _cubeMaterial = cubeMeshRenderer.material;
+
+            // Instantiate the material once; Initialize is re-runnable via Handle.ChangeAxes
+            // and MeshRenderer.material allocates a new instance on every access.
+            if (_cubeMaterial == null) _cubeMaterial = cubeMeshRenderer.material;
         }
 
         /// <inheritdoc/>

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleHandle.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleHandle.cs
@@ -14,39 +14,44 @@ namespace TransformHandles
         public ScaleGlobal globalScale;
 
         private Handle _parentHandle;
-        private bool _handleInitialized;
         private bool _globalScaleSubscribed;
 
         /// <summary>
         /// Initializes the scale handle with all its axes.
+        /// Re-runnable so <see cref="Handle.ChangeAxes"/> can filter visible axes after creation.
         /// </summary>
         /// <param name="handle">The parent handle.</param>
         public void Initialize(Handle handle)
         {
-            if (_handleInitialized) return;
-
             _parentHandle = handle;
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.X))
-                xAxis.Initialize(_parentHandle, Vector3.right);
+            var hasX = handle.axes.HasAxis(HandleAxes.X);
+            var hasY = handle.axes.HasAxis(HandleAxes.Y);
+            var hasZ = handle.axes.HasAxis(HandleAxes.Z);
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.Y))
-                yAxis.Initialize(_parentHandle, Vector3.up);
+            xAxis.gameObject.SetActive(hasX);
+            if (hasX) xAxis.Initialize(handle, Vector3.right);
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.Z))
-                zAxis.Initialize(_parentHandle, Vector3.forward);
+            yAxis.gameObject.SetActive(hasY);
+            if (hasY) yAxis.Initialize(handle, Vector3.up);
 
-            if (_parentHandle.axes.IsMultiAxis())
+            zAxis.gameObject.SetActive(hasZ);
+            if (hasZ) zAxis.Initialize(handle, Vector3.forward);
+
+            var multiAxis = handle.axes.IsMultiAxis();
+            globalScale.gameObject.SetActive(multiAxis);
+            if (multiAxis)
             {
-                globalScale.Initialize(_parentHandle, HandleBase.GetVectorFromAxes(_parentHandle.axes));
+                globalScale.Initialize(handle, HandleBase.GetVectorFromAxes(handle.axes));
 
-                globalScale.InteractionStart += OnGlobalInteractionStart;
-                globalScale.InteractionUpdate += OnGlobalInteractionUpdate;
-                globalScale.InteractionEnd += OnGlobalInteractionEnd;
-                _globalScaleSubscribed = true;
+                if (!_globalScaleSubscribed)
+                {
+                    globalScale.InteractionStart += OnGlobalInteractionStart;
+                    globalScale.InteractionUpdate += OnGlobalInteractionUpdate;
+                    globalScale.InteractionEnd += OnGlobalInteractionEnd;
+                    _globalScaleSubscribed = true;
+                }
             }
-
-            _handleInitialized = true;
         }
 
         private void OnDestroy()
@@ -62,28 +67,37 @@ namespace TransformHandles
 
         private void OnGlobalInteractionStart()
         {
-            xAxis.SetColor(Color.yellow);
-            yAxis.SetColor(Color.yellow);
-            zAxis.SetColor(Color.yellow);
+            if (_parentHandle.axes.HasAxis(HandleAxes.X)) xAxis.SetColor(Color.yellow);
+            if (_parentHandle.axes.HasAxis(HandleAxes.Y)) yAxis.SetColor(Color.yellow);
+            if (_parentHandle.axes.HasAxis(HandleAxes.Z)) zAxis.SetColor(Color.yellow);
         }
 
         private void OnGlobalInteractionUpdate(float scaleDelta)
         {
-            xAxis.delta = scaleDelta;
-            yAxis.delta = scaleDelta;
-            zAxis.delta = scaleDelta;
+            if (_parentHandle.axes.HasAxis(HandleAxes.X)) xAxis.delta = scaleDelta;
+            if (_parentHandle.axes.HasAxis(HandleAxes.Y)) yAxis.delta = scaleDelta;
+            if (_parentHandle.axes.HasAxis(HandleAxes.Z)) zAxis.delta = scaleDelta;
         }
 
         private void OnGlobalInteractionEnd()
         {
-            xAxis.SetDefaultColor();
-            xAxis.delta = 0;
+            if (_parentHandle.axes.HasAxis(HandleAxes.X))
+            {
+                xAxis.SetDefaultColor();
+                xAxis.delta = 0;
+            }
 
-            yAxis.SetDefaultColor();
-            yAxis.delta = 0;
+            if (_parentHandle.axes.HasAxis(HandleAxes.Y))
+            {
+                yAxis.SetDefaultColor();
+                yAxis.delta = 0;
+            }
 
-            zAxis.SetDefaultColor();
-            zAxis.delta = 0;
+            if (_parentHandle.axes.HasAxis(HandleAxes.Z))
+            {
+                zAxis.SetDefaultColor();
+                zAxis.delta = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- `PositionHandle`/`RotationHandle`/`ScaleHandle.Initialize` is no longer gated by `_handleInitialized`, so the second call from `Handle.ChangeAxes` (`Clear` + `CreateHandles`) actually applies the new mask. Each axis/plane/`globalScale` is toggled with `SetActive(maskHasIt)` so removed axes go away and re-selected ones come back.
- `PositionPlane` GameObjects ship as children of the axis GameObjects in `NativeTransformHandle.prefab`, so deactivating an axis would also hide its child plane in the hierarchy. `PositionHandle.Initialize` now reparents the three planes onto the `PositionHandle` GameObject (idempotent), decoupling plane visibility from axis activation.
- `ScaleHandle`'s `OnGlobalInteractionStart/Update/End` previously called `SetColor` and wrote `delta` on all three axes unconditionally. With masking, an inactive axis is never `Initialize`d, so its cached materials are null and `SetColor` would NPE. Each branch is now gated by `_parentHandle.axes.HasAxis(...)`.
- `globalScale` event subscription is gated by `_globalScaleSubscribed` so it can't double-subscribe across re-initializations.

Closes #10. Supersedes #13 (which was closed; this revision addresses all three review concerns raised on that PR).

## Out of scope

Copilot's review on #13 also flagged that the `PositionPlane.Initialize` args for `xPlane`/`yPlane`/`zPlane` don't match the axis pair that enables each plane (e.g., `zPlane` activates on `HasBothAxes(X, Y)` but is configured as the YZ plane — `perp = -X`). That mismatch is pre-existing on `main` and not introduced by this PR; filing as a separate issue rather than expanding scope here.

## Test plan

- [ ] `handle = manager.CreateHandle(t); handle.ChangeAxes(HandleAxes.Y);` shows only the Y axis.
- [ ] `handle.ChangeAxes(HandleAxes.XY);` shows X + Y arrows plus one plane gizmo.
- [ ] Cycling `ChangeAxes(XYZ) -> Y -> XYZ` restores all axes/planes correctly.
- [ ] `HandleType.Rotation` rings follow the mask after `ChangeAxes`.
- [ ] `HandleType.Scale` axes follow the mask; the center (`globalScale`) handle appears only when the mask is multi-axis.
- [ ] Starting with `HandleAxes.YZ` and dragging `globalScale` does not throw (X axis is masked out and uninitialized).
- [ ] `globalScale` drag still fires `InteractionStart/Update/End` exactly once after toggling `ChangeAxes`.