### PR TITLE
fix: add missing .meta for TransformHandleSettings (closes #11)

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleSettings.cs.meta
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleSettings.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 50fbf1fa812a47279be52909b0f98245
+timeCreated: 1748000000


### PR DESCRIPTION
## Summary

`Runtime/Scripts/TransformHandleSettings.cs` shipped without its `.cs.meta` file. When the package is consumed via git URL (immutable `Packages/` folder), Unity can't generate the meta and logs:

> Asset Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleSettings.cs has no meta file, but it's in an immutable folder. The asset will be ignored.

The script is then ignored, so the settings type fails to import. Every other `.cs` in the package has a tracked `.meta` (36 of them) — this one was missed.

This adds the meta file with a fresh GUID (collision-checked against existing metas).

Closes #11.

## Test plan

- [ ] Import the package via git URL into a clean project; confirm no "no meta file" warning and `TransformHandleSettings` is usable.