### PR TITLE
fix: position-plane masking + scale-delta hardening + EditMode tests

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionHandle.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Position/PositionHandle.cs
@@ -49,14 +49,17 @@ namespace TransformHandles
             var hasYZ = handle.axes.HasBothAxes(HandleAxes.Y, HandleAxes.Z);
             var hasXZ = handle.axes.HasBothAxes(HandleAxes.X, HandleAxes.Z);
 
-            zPlane.gameObject.SetActive(hasXY);
-            if (hasXY) zPlane.Initialize(handle, Vector3.forward, Vector3.up, -Vector3.right);
+            // Each plane's quad mesh, raycast normal (perp) and visual offset already agree in
+            // the prefab: zPlane=YZ (perp -X), xPlane=XZ (perp Y), yPlane=XY (perp Z). Enable each
+            // on the matching axis pair so dragging the gizmo moves in the plane it renders.
+            zPlane.gameObject.SetActive(hasYZ);
+            if (hasYZ) zPlane.Initialize(handle, Vector3.forward, Vector3.up, -Vector3.right);
 
-            xPlane.gameObject.SetActive(hasYZ);
-            if (hasYZ) xPlane.Initialize(handle, Vector3.right, Vector3.forward, Vector3.up);
+            xPlane.gameObject.SetActive(hasXZ);
+            if (hasXZ) xPlane.Initialize(handle, Vector3.right, Vector3.forward, Vector3.up);
 
-            yPlane.gameObject.SetActive(hasXZ);
-            if (hasXZ) yPlane.Initialize(handle, Vector3.right, Vector3.up, Vector3.forward);
+            yPlane.gameObject.SetActive(hasXY);
+            if (hasXY) yPlane.Initialize(handle, Vector3.right, Vector3.up, Vector3.forward);
         }
     }
 }

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleHandle.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleHandle.cs
@@ -81,23 +81,17 @@ namespace TransformHandles
 
         private void OnGlobalInteractionEnd()
         {
-            if (_parentHandle.axes.HasAxis(HandleAxes.X))
-            {
-                xAxis.SetDefaultColor();
-                xAxis.delta = 0;
-            }
+            // delta is a plain field, safe to clear even on an axis masked out mid-drag and
+            // never Initialized; clearing all three avoids a stale delta resurfacing through
+            // ScaleAxis.Update if the axis is re-enabled later. SetDefaultColor touches cached
+            // materials (null on uninitialized axes), so gate only the color reset by the mask.
+            xAxis.delta = 0;
+            yAxis.delta = 0;
+            zAxis.delta = 0;
 
-            if (_parentHandle.axes.HasAxis(HandleAxes.Y))
-            {
-                yAxis.SetDefaultColor();
-                yAxis.delta = 0;
-            }
-
-            if (_parentHandle.axes.HasAxis(HandleAxes.Z))
-            {
-                zAxis.SetDefaultColor();
-                zAxis.delta = 0;
-            }
+            if (_parentHandle.axes.HasAxis(HandleAxes.X)) xAxis.SetDefaultColor();
+            if (_parentHandle.axes.HasAxis(HandleAxes.Y)) yAxis.SetDefaultColor();
+            if (_parentHandle.axes.HasAxis(HandleAxes.Z)) zAxis.SetDefaultColor();
         }
     }
 }

--- a/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/GetVectorFromAxesTests.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/GetVectorFromAxesTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace TransformHandles.Tests
+{
+    /// <summary>
+    /// Covers HandleBase.GetVectorFromAxes, which converts an axis mask to the
+    /// per-component multiplier ScaleGlobal applies during uniform scaling.
+    /// A wrong vector scales the wrong axes.
+    /// </summary>
+    [TestFixture]
+    public class GetVectorFromAxesTests
+    {
+        private static readonly object[] Cases =
+        {
+            new object[] { HandleAxes.X, new Vector3(1, 0, 0) },
+            new object[] { HandleAxes.Y, new Vector3(0, 1, 0) },
+            new object[] { HandleAxes.Z, new Vector3(0, 0, 1) },
+            new object[] { HandleAxes.XY, new Vector3(1, 1, 0) },
+            new object[] { HandleAxes.XZ, new Vector3(1, 0, 1) },
+            new object[] { HandleAxes.YZ, new Vector3(0, 1, 1) },
+            new object[] { HandleAxes.XYZ, new Vector3(1, 1, 1) },
+        };
+
+        [TestCaseSource(nameof(Cases))]
+        public void GetVectorFromAxes_MapsMaskToMultiplier(HandleAxes axes, Vector3 expected)
+        {
+            Assert.AreEqual(expected, HandleBase.GetVectorFromAxes(axes));
+        }
+    }
+}

--- a/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/GetVectorFromAxesTests.cs.meta
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/GetVectorFromAxesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb3cd9ffd9c14f0e92fd9ed01f4ec2f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Follow-up to #14 (merged). Two commits left the branch after #14 merged, plus new test coverage.

## Changes

**`fix: enable each position plane on the axis pair it actually constrains` (closes #15)**
Each `PositionPlane`'s quad mesh, raycast normal (`perp`) and visual offset already agree in the prefab (`zPlane`=YZ, `xPlane`=XZ, `yPlane`=XY), but the `SetActive` enable conditions were cross-wired — selecting `HandleAxes.XY` showed a plane that dragged in YZ. Re-point each enable flag at the matching pair. No prefab or `Initialize`-arg change (constraint + visual were never the broken part).

**`test: harden global-scale delta reset`**
`OnGlobalInteractionEnd` reset `delta` only for axes still in the mask. An axis masked out mid global-scale drag kept a stale `delta` that resurfaced through `ScaleAxis.Update` if re-enabled later. Now clears all three (`delta` is a plain field, safe on an uninitialized axis); only `SetDefaultColor` (touches cached materials) stays mask-gated.

## Tests (new)

First automated coverage in the package. `TransformHandles.Tests.Editor` (EditMode, `UNITY_INCLUDE_TESTS`-guarded so it only compiles under the test runner):

- `HandleAxesExtensionsTests` — `HasAxis` / `HasBothAxes` / `IsMultiAxis` across all 7 `HandleAxes` values. This is the mask logic that drives which axes/planes each handle shows (regression guard for #10 / #15).
- `GetVectorFromAxesTests` — `HandleBase.GetVectorFromAxes` mask→multiplier mapping used by `ScaleGlobal`.

**43 cases, all passing** under Unity 6000.3.2f1 (`-runTests -testPlatform EditMode`).

## Test plan
- [ ] `ChangeAxes(HandleAxes.XY)` shows a plane gizmo that drags in XY (not YZ).
- [ ] Global-scale drag, then `ChangeAxes` dropping an axis, then re-add it — no stale scale offset.
- [ ] `Window > General > Test Runner > EditMode > Run All` → 43 green.