### PR TITLE
docs: 2.0 migration guide, API reference, sample README + root README sync

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 This release contains **source-breaking** changes and is intended to ship as **2.0.0**.
+Migration steps: see `Documentation~/migration-1.x-to-2.0.md`.
 
 ### Breaking
 - **Namespaces:** `Singleton<T>`, `ApplicationQuitManager`, and `PreserveScaleOnScreenExtension`

--- a/Packages/com.orkunmanap.runtime-transform-handles/Documentation~/index.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Documentation~/index.md
@@ -46,4 +46,56 @@ Settings (`ENABLE_INPUT_SYSTEM`); otherwise the legacy Input Manager is used.
 Handles require a dedicated physics layer (default name `TransformHandle`). Create it via
 `Tools > Transform Handles > Setup Layer`.
 
-See the package `README.md` for the API quick start and keyboard shortcuts.
+## API reference
+
+### `TransformHandleManager` (singleton — `TransformHandleManager.Instance`)
+
+| Member | Description |
+|--------|-------------|
+| `Handle CreateHandle(Transform target)` | Create a handle for one object. Throws `ArgumentNullException` if `target` is null; warns + returns null if it already has a handle. |
+| `Handle CreateHandleFromList(List<Transform> targets)` | Create one handle controlling several objects. Throws on null/empty list. |
+| `bool AddTarget(Transform target, Handle handle)` | Add an object to an existing handle. Throws if `handle` is null/unmanaged. |
+| `void RemoveTarget(Transform target, Handle handle)` | Remove an object; destroys the handle when its last target leaves. |
+| `void RemoveHandle(Handle handle)` | Stop managing + tear down a handle. |
+| `void DestroyAllHandles()` | Destroy every handle and clear all state. |
+| `static void ChangeHandleType(Handle, HandleType)` | Set a handle's type. |
+| `void ChangeHandleSpace(Handle, Space)` | Set a handle's space and re-center the ghost. |
+| `void ChangeHandlePivot(TransformGroup, bool originToCenter)` | Toggle pivot vs. bounds-center origin. |
+| `Camera mainCamera` | Camera used for raycasting (settable; falls back to `Camera.main`). |
+| `TransformHandleSettings Settings` | Optional settings asset (overrides serialized defaults). |
+
+### `Handle`
+
+| Member | Description |
+|--------|-------------|
+| `Transform target` | Manipulated transform (**read-only**; set via `CreateHandle`/`Enable`). |
+| `Camera handleCamera` | Camera for screen math (**read-only**; set when enabled). |
+| `HandleType type` | Property; assigning rebuilds the child handles. |
+| `HandleAxes axes` | Property; assigning rebuilds the child handles. |
+| `Space space` | Property; setter clamps Scale handles to `Space.Self`. |
+| `SnappingType snappingType` | `Relative` or `Absolute`. |
+| `Vector3 positionSnap` / `float rotationSnap` / `Vector3 scaleSnap` | Snap increments (0 = off). |
+| `bool autoScale` / `float ScaleMultiplier` / `AutoScaleSizeInPixels` | Constant on-screen sizing. |
+| events `OnInteractionStartEvent` / `OnInteractionEvent` / `OnInteractionEndEvent` / `OnHandleDestroyedEvent` | `Action<Handle>`. Inspector-friendly `*UnityEvent` mirrors exist. |
+| `void ApplySettings(TransformHandleSettings)` | Apply scale/appearance from a settings asset. |
+
+> `ChangeHandleType`/`ChangeHandleSpace`/`ChangeAxes` are `[Obsolete]` — assign the `type`/`space`/`axes` properties instead.
+
+### Enums
+
+- `HandleType`: `Position, Rotation, Scale, PositionRotation, PositionScale, RotationScale, All`
+- `HandleAxes`: `X, Y, Z, XY, XZ, YZ, XYZ`
+- `SnappingType`: `Relative, Absolute`
+- `Space`: `Self` (local), `World`
+- `Origin`: `Pivot, Center`
+
+### `TransformHandleSettings` (ScriptableObject — `Assets > Create > Transform Handles > Settings`)
+
+Keyboard shortcuts (enable/disable + rebind), default handle type/space/axes for new handles, and
+highlight color. Assign to `TransformHandleManager.Instance.Settings`.
+
+## Upgrading
+
+See [migration-1.x-to-2.0.md](migration-1.x-to-2.0.md) for the 2.0 breaking-change migration steps.
+
+See the package `README.md` for the quick start and keyboard shortcuts.

--- a/Packages/com.orkunmanap.runtime-transform-handles/Documentation~/migration-1.x-to-2.0.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Documentation~/migration-1.x-to-2.0.md
@@ -1,0 +1,102 @@
+# Migrating from 1.x to 2.0
+
+2.0.0 is a **source-breaking** release. Most projects need only a couple of small edits.
+Work through the items below; each shows the old code and the 2.0 replacement.
+
+## 0. Requirements changed
+
+- **Minimum Unity is now 2021.3** (was an incorrect `2019.4` — the code never compiled on 2019.4).
+  Projects below 2021.3 must stay on 1.x.
+- **URP is now a package dependency** (`com.unity.render-pipelines.universal`). The handle shaders
+  ship a URP SubShader whose include must always resolve. Built-in projects are unaffected at
+  render time — the Built-in SubShader is still used; URP being *installed* does not make it the
+  *active* pipeline. HDRP is not supported out of the box.
+
+## 1. `using` for the utility types (only if you referenced them)
+
+`Singleton<T>`, `ApplicationQuitManager`, and `PreserveScaleOnScreen` moved out of the **global
+namespace** into `TransformHandles.Utils` (this is what fixes the `CS0436`/`CS0104` collisions with
+your own `Singleton<T>`). `ApplicationQuitManager` and `PreserveScaleOnScreen` are now `internal`.
+
+```csharp
+// before — relied on the package's global Singleton<T>
+public class MyManager : Singleton<MyManager> { }
+
+// after
+using TransformHandles.Utils;
+public class MyManager : Singleton<MyManager> { }
+```
+
+If you had your *own* global `Singleton<T>` that collided with the package's, **you can delete the
+workaround** — the collision is gone.
+
+## 2. `Change*` methods → property assignment
+
+`Handle.ChangeHandleType`, `ChangeHandleSpace`, and `ChangeAxes` are now `[Obsolete]` (they still
+work, with a warning). Assign the properties directly — their setters do the right thing
+(`type`/`axes` rebuild the child handles, `space` applies the Scale-is-always-Self clamp):
+
+```csharp
+// before
+handle.ChangeHandleType(HandleType.Rotation);
+handle.ChangeHandleSpace(Space.World);
+handle.ChangeAxes(HandleAxes.XY);
+
+// after
+handle.type  = HandleType.Rotation;
+handle.space = Space.World;
+handle.axes  = HandleAxes.XY;
+```
+
+`TransformHandleManager.ChangeHandleType(handle, type)` and `ChangeHandleSpace(handle, space)` are
+unchanged and now route through the setters internally.
+
+## 3. `target` and `handleCamera` are read-only
+
+`Handle.target` and `Handle.handleCamera` are now read-only properties (set by the package when the
+handle is enabled). Reading them is unchanged; **assigning** them no longer compiles.
+
+```csharp
+// before (no longer compiles)
+handle.target = myTransform;
+
+// after — create the handle for the target instead
+var handle = TransformHandleManager.Instance.CreateHandle(myTransform);
+// add/remove more targets:
+TransformHandleManager.Instance.AddTarget(other, handle);
+TransformHandleManager.Instance.RemoveTarget(other, handle);
+```
+
+## 4. Public methods now throw on contract violations
+
+`CreateHandle`, `CreateHandleFromList`, `AddTarget`, `RemoveTarget`, `RemoveHandle`,
+`ChangeHandleType`, `ChangeHandleSpace`, and `ChangeHandlePivot` now throw
+`ArgumentNullException` (and `ArgumentException`/`InvalidOperationException`) on null/empty/unmanaged
+arguments, instead of logging an error and returning `null`/`false`. Benign state conditions
+("target already has a handle", target not found) still log a warning and no-op.
+
+```csharp
+// before — returned null on a null target
+var handle = TransformHandleManager.Instance.CreateHandle(maybeNull);
+if (handle == null) { ... }
+
+// after — guard before calling
+if (maybeNull == null) return;
+var handle = TransformHandleManager.Instance.CreateHandle(maybeNull);
+```
+
+## 5. Reduced public surface (`internal`)
+
+`Ghost`'s interaction callbacks (`OnInteractionStart`, `OnInteraction`, `UpdateGhostTransform`,
+`ResetGhostTransform`, `Terminate`) and `TransformGroup`'s `UpdatePositions`/`UpdateRotations`/
+`UpdateScales`/`UpdateBounds` plus the `Transforms`/`RenderersMap`/`BoundsMap` collections are now
+`internal`. These were internal-use plumbing driven by the manager; if you called them directly,
+drive interaction through the public `Handle`/`TransformHandleManager` API and the `Handle` events
+(`OnInteractionStartEvent`, `OnInteractionEvent`, `OnInteractionEndEvent`) instead.
+
+## Not breaking, but worth knowing
+
+- `type`, `axes`, `space`, `snappingType`, `positionSnap`, `rotationSnap`, `scaleSnap` are now
+  properties (same names — your reads/writes still compile). Writing `type` or `axes` now rebuilds
+  the child handles immediately; previously a raw field write left stale children.
+- Prefab/inspector values for those fields are preserved across the upgrade (`FormerlySerializedAs`).

--- a/Packages/com.orkunmanap.runtime-transform-handles/README.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/README.md
@@ -106,6 +106,10 @@ TransformHandleManager.Instance.Settings = mySettings;
 Import the **Runtime Transform Handles Demo** from the package's Samples tab in the Package Manager
 for a selection + multi-object manipulation example scene.
 
+## Upgrading from 1.x
+
+2.0.0 is a breaking release. See `Documentation~/migration-1.x-to-2.0.md` for the (small) steps.
+
 ## License
 
 MIT — see `LICENSE.md`.

--- a/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/README.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/README.md
@@ -1,0 +1,31 @@
+# Runtime Transform Handles — Demo
+
+Open `RuntimeTransformHandlesDemo.unity` and press **Play**. The scene is self-contained:
+`HandleDemo` spawns its own target cubes, ensures a camera, and draws an on-screen control panel.
+
+> First run only: create the physics layer the handles raycast against —
+> `Tools > Transform Handles > Setup Layer`.
+
+## Controls
+
+| Input | Action |
+|-------|--------|
+| **Left click** a cube | Select it (creates/handles a gizmo) |
+| **Shift + left click** | Add the cube to the current multi-selection |
+| **Right click** a cube | Drop it from its handle |
+| **Drag a gizmo axis/plane** | Move / rotate / scale the selection |
+| **Middle-mouse drag** | Orbit the camera |
+| **Scroll wheel** | Zoom |
+| **W / E / R / A** | Position / Rotation / Scale / All modes |
+| **X** | Toggle World / Local space |
+| **Z** | Toggle Pivot / Center origin |
+
+## What it demonstrates
+
+- Single- and multi-object selection and grouped manipulation.
+- Every `HandleType`, `HandleAxes` mask, `Space`, and `SnappingType` (driven live from the panel).
+- Auto-scaling handles, handle scale multiplier, and a runtime `TransformHandleSettings` asset.
+- All interaction events (`OnInteractionStart/Event/End`, `OnHandleDestroyed`).
+
+The picking raycast uses a layer mask that excludes the handle-gizmo layer so clicks hit objects,
+not the gizmos.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Icon](https://i.imgur.com/NRdmzlQ.png)
 
-[![Unity 2019.4+](https://img.shields.io/badge/Unity-2019.4%2B-blue.svg)](https://unity.com/)
+[![Unity 2021.3+](https://img.shields.io/badge/Unity-2021.3%2B-blue.svg)](https://unity.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/manaporkun/UnityRuntimeTransformHandles?include_prereleases)](https://github.com/manaporkun/UnityRuntimeTransformHandles/releases)
 [![OpenUPM](https://img.shields.io/badge/OpenUPM-compatible-blue.svg)](https://openupm.com/)
@@ -33,8 +33,16 @@ Unity Runtime Transform Handles is a powerful tool that allows developers to tra
 
 ## Requirements
 
-- Unity **2019.4** or higher
-- Works with both **Legacy Input Manager** and **New Input System** (auto-detected via `ENABLE_INPUT_SYSTEM` preprocessor)
+- Unity **2021.3** or higher.
+- **Render pipeline:** Built-in and URP (the handle shaders ship both SubShaders, auto-selected).
+  URP (`com.unity.render-pipelines.universal`) is a package dependency so the URP shader includes
+  always resolve; Built-in projects still render via the Built-in SubShader. HDRP is not supported
+  out of the box.
+- **Input:** Works with the **Legacy Input Manager** out of the box; uses the **New Input System**
+  automatically when `com.unity.inputsystem` is present and enabled (no setup required).
+
+> **Upgrading from 1.x?** 2.0.0 is a breaking release — see the
+> [migration guide](Packages/com.orkunmanap.runtime-transform-handles/Documentation~/migration-1.x-to-2.0.md).
 
 ## Installation
 
@@ -66,7 +74,7 @@ To install a specific version, append the version tag:
 ```json
 {
     "dependencies": {
-        "com.orkunmanap.runtime-transform-handles": "https://github.com/manaporkun/UnityRuntimeTransformHandles.git#v1.16.0"
+        "com.orkunmanap.runtime-transform-handles": "https://github.com/manaporkun/UnityRuntimeTransformHandles.git#v2.0.0"
     }
 }
 ```
@@ -191,15 +199,24 @@ Packages/com.orkunmanap.runtime-transform-handles/
 │   │   │   ├── Position/                    # PositionHandle, PositionAxis, PositionPlane
 │   │   │   ├── Rotation/                    # RotationHandle, RotationAxis
 │   │   │   └── Scale/                       # ScaleHandle, ScaleAxis, ScaleGlobal
-│   │   ├── Utils/                           # InputWrapper, MathUtils, MeshUtils, Singleton
+│   │   ├── Utils/                           # InputWrapper, MathUtils, MeshUtils, SnapUtils, Singleton
 │   │   ├── Ghost.cs                         # Pivot point for manipulation
 │   │   ├── Handle.cs                        # Per-target handle controller
 │   │   ├── TransformGroup.cs                # Multi-object grouping
 │   │   ├── TransformHandleManager.cs        # Central singleton manager
 │   │   └── TransformHandleSettings.cs       # ScriptableObject settings
-│   └── Shader/                              # Handle and origin shaders
+│   └── Shader/                              # Handle and origin shaders (Built-in + URP)
+├── Tests/                                   # EditMode + PlayMode test assemblies
+├── Samples~/Demo/                           # Importable demo sample (Package Manager)
+├── Documentation~/                          # index.md (architecture + API) + migration guide
 └── package.json
 ```
+
+## Documentation
+
+- **API + architecture:** `Documentation~/index.md` in the package.
+- **Upgrading to 2.0:** [`Documentation~/migration-1.x-to-2.0.md`](Packages/com.orkunmanap.runtime-transform-handles/Documentation~/migration-1.x-to-2.0.md).
+- **Changelog:** [`CHANGELOG.md`](Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md).
 
 ## Main Components
 


### PR DESCRIPTION
Closes the doc gaps before the 2.0.0 release.

- **NEW** `Documentation~/migration-1.x-to-2.0.md` — step-by-step 1.x→2.0 (namespace move, `Change*`→property setters, read-only `target`/`handleCamera`, throw-on-null, internal scoping, URP dependency, Unity 2021.3 floor).
- `Documentation~/index.md` — added a full API reference (manager / Handle / enums / settings) + migration link.
- **NEW** `Samples~/Demo/README.md` — controls table + what the demo exercises.
- Root `README.md` — synced: Unity **2021.3**, render-pipeline + URP-dependency note, `TH_INPUTSYSTEM` wording, `v2.0.0` install example, `Tests/`/`Samples~`/`Documentation~` in the structure, new Documentation section.
- Package `README.md` + `CHANGELOG.md` — link the migration guide.

Docs-only; targets `develop`.