### PR TITLE
fix: world-space group rotation + multi-renderer bounds

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformGroup.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformGroup.cs
@@ -125,14 +125,19 @@ namespace TransformHandles
             }
             else
             {
-                // eulerAngles conversions are only needed for the world-space RotateAround path;
-                // computing them up front wasted two quaternion->euler conversions every frame in Self space.
-                var rotationAxis = rotationChange.normalized.eulerAngles;
-                var rotationChangeMagnitude = rotationChange.eulerAngles.magnitude;
+                // Decompose the delta quaternion into a true axis + angle. The previous code used
+                // rotationChange.eulerAngles as the axis and its magnitude as the angle, which is
+                // not a valid axis/angle decomposition (it only happened to work for small
+                // single-axis rotations and diverged for compound/off-axis or large deltas).
+                rotationChange.ToAngleAxis(out var angleInDegrees, out var rotationAxis);
+
+                // ToAngleAxis returns angle 0 (axis (1,0,0)) for the identity delta; skip the
+                // no-op work and guard against any non-finite axis from float drift.
+                if (Mathf.Approximately(angleInDegrees, 0f) || float.IsNaN(rotationAxis.x)) return;
 
                 foreach (var target in RenderersMap.Keys)
                 {
-                    target.RotateAround(ghostPosition, rotationAxis, rotationChangeMagnitude);
+                    target.RotateAround(ghostPosition, rotationAxis, angleInDegrees);
                 }
             }
         }

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/Utils/TransformUtils.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/Utils/TransformUtils.cs
@@ -16,21 +16,25 @@ namespace TransformHandles.Utils
 
         public static Bounds GetBounds(this Transform transform)
         {
-            var bounds = new Bounds(Vector3.zero, Vector3.zero);
             var renderers = transform.GetComponentsInChildren<Renderer>();
-            var renderersCount = renderers.Length;
-            
-            var averageCenter = Vector3.zero;
-            var averageSize = Vector3.zero;
-            foreach (var renderer in renderers)
+
+            // No renderers: return a zero-size bounds at the transform position. The previous
+            // code divided by renderers.Length here and produced NaN bounds for renderer-less
+            // targets (e.g. empty pivots), which then poisoned pivot/center placement.
+            if (renderers.Length == 0)
             {
-                var bound = renderer.bounds;
-                averageCenter += bound.center;
-                averageSize += bound.size;
+                return new Bounds(transform.position, Vector3.zero);
             }
-            bounds.center = averageCenter/renderersCount;
-            bounds.size = averageSize/renderersCount;
-            
+
+            // Encapsulate every child renderer into one combined AABB. Averaging the centers and
+            // sizes (the previous approach) yielded a box that neither contained the children nor
+            // sat at their collective center once more than one renderer was involved.
+            var bounds = renderers[0].bounds;
+            for (var i = 1; i < renderers.Length; i++)
+            {
+                bounds.Encapsulate(renderers[i].bounds);
+            }
+
             return bounds;
         }
     }


### PR DESCRIPTION
Correctness fixes surfaced by the package quality review (overall **B-, 70.7/100**). Two unambiguous, statically-verifiable bugs; fixed here. The remaining higher-risk findings (release-pipeline over-bumping, URP hard dependency, Input System asmdef reference, multi-target average rotation) are **not** in this PR — they need Unity/CI verification or are packaging decisions, tracked separately.

## Fixes

### 1. World-space group rotation math — `TransformGroup.UpdateRotations`
The world-space path treated `rotationChange.eulerAngles` as a rotation **axis** and its `.magnitude` as the **angle**:
```csharp
var rotationAxis = rotationChange.normalized.eulerAngles;
var rotationChangeMagnitude = rotationChange.eulerAngles.magnitude;
target.RotateAround(ghostPosition, rotationAxis, rotationChangeMagnitude);
```
That is not a valid axis/angle decomposition — it only approximates correct behaviour for small single-axis deltas and diverges for compound, off-axis, or large rotations. Replaced with `Quaternion.ToAngleAxis` (the correct decomposition) plus an identity/NaN guard. The Self-space path was already correct and is untouched.

### 2. Multi-renderer bounds — `TransformUtils.GetBounds`
Averaged child renderer centers/sizes (a box that neither contains the children nor sits at their center) and divided by `renderers.Length` with **no zero guard** → NaN bounds for renderer-less targets. Replaced with `Bounds.Encapsulate` over all child renderers + a zero-renderer fallback.

## Verification
- Static/logical only — both are formula-level corrections using standard Unity APIs (`Quaternion.ToAngleAxis`, `Bounds.Encapsulate`). **No PlayMode verification performed** (no Unity runtime here). Recommend a quick manual multi-object world-space rotate + a renderer-less-target selection before release.
- CI `Validate package` + `Tests (EditMode + PlayMode)` will run on this PR.

## ⚠️ Release pipeline note
The auto-versioning is currently mis-bumping (PR #23 was `refactor`+`chore` yet bumped **2.0.0 → 3.0.0** major, because tags live on the orphan `upm` branch and the bump scans full repo history). Merging this `fix:` PR may produce another wrong bump. Hold the merge until the release pipeline is fixed, or correct the resulting version manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized correctness fixes to transform gizmo math and bounds; no auth, persistence, or API surface changes beyond behavior fixes consumers likely want.
> 
> **Overview**
> Fixes two math bugs in the runtime transform-handles package that affected **world-space group rotation** and **bounds used for pivots / center-on-bounds**.
> 
> **World-space rotation** (`TransformGroup.UpdateRotations`): Replaces the invalid use of `rotationChange.eulerAngles` as axis and its magnitude as angle with `Quaternion.ToAngleAxis`, then `RotateAround` with the real axis and degrees. Adds an early return for identity deltas and non-finite axes. Self-space rotation is unchanged.
> 
> **Combined bounds** (`TransformUtils.GetBounds`): Stops averaging child renderer centers/sizes (wrong for multiple renderers) and dividing by zero when there are no renderers (NaN bounds). Now returns a zero-size bounds at the transform position when empty, otherwise a single AABB via `Bounds.Encapsulate` over all child renderers—used when adding/updating group members without a root `MeshRenderer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b77575d24787131f94ecef2b525b37ad73d117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->