### PR TITLE
ci: fix release version over-bumping (tag-independent range)

### DIFF
--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -134,16 +134,32 @@ jobs:
       - name: Determine version bump
         id: bump
         run: |
-          # Latest tag (fallback to v0.0.0 for the first release).
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo "Latest tag: $LATEST_TAG"
+          # Release boundary = the last automated version-bump commit on main. Tags are created
+          # on the orphan `upm` branch, which is NOT reachable from main, so `git describe --tags`
+          # found nothing here and the range fell back to the ENTIRE history — re-counting old
+          # BREAKING/feat commits and over-bumping (major) on every release. The bump commit is
+          # always reachable from main, so it is a reliable, tag-independent boundary.
+          RANGE_START=$(git log --grep='^chore: bump version to' --format=%H -n 1 HEAD || true)
+
+          if [ -n "$RANGE_START" ]; then
+            RANGE="$RANGE_START..HEAD"
+            echo "Previous release commit: $RANGE_START"
+          else
+            RANGE="HEAD"
+            echo "No previous bump commit found; treating all history as the first release."
+          fi
+          echo "Commit range: $RANGE"
 
           # Read FULL commit messages (%B) so `BREAKING CHANGE:` body/footer lines are seen,
           # not just subjects.
-          COMMITS=$(git log $LATEST_TAG..HEAD --format=%B 2>/dev/null || git log --format=%B)
-
-          echo "Commits since $LATEST_TAG:"
+          COMMITS=$(git log $RANGE --format=%B)
+          echo "Commits in range:"
           echo "$COMMITS"
+
+          # Subjects for the changelog / release notes, computed once here (on main) and reused by
+          # later steps via this file — later steps run while checked out on the `upm` branch, where
+          # re-deriving the range would be wrong.
+          git log $RANGE --pretty=format:"- %s" > /tmp/release_entries.md
 
           # Strict Conventional Commits only — no bare ^break/^feature/^bugfix aliases
           # (they mis-bump), and no catch-all "any change -> patch" fallback.
@@ -157,8 +173,8 @@ jobs:
           elif echo "$COMMITS" | grep -qiE "^(fix|perf|refactor)(\(.+\))?:"; then
             BUMP="patch"
           elif echo "$COMMITS" | grep -qiE "^(docs|style|chore|ci|test|build)(\(.+\))?:"; then
-            # Housekeeping types only bump when actual code/manifest changed.
-            if git diff $LATEST_TAG..HEAD --name-only 2>/dev/null | grep -qE "\.cs$|package\.json$"; then
+            # Housekeeping types only bump when actual code/manifest changed in the range.
+            if git log $RANGE --name-only --pretty=format: | sort -u | grep -qE "\.cs$|package\.json$"; then
               BUMP="patch"
             fi
           fi
@@ -217,13 +233,9 @@ jobs:
         run: |
           NEW_VERSION="${{ steps.version.outputs.version }}"
           CHANGELOG="Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md"
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
-          if [ -z "$LATEST_TAG" ]; then
-            ENTRIES=$(git log --pretty=format:"- %s" HEAD)
-          else
-            ENTRIES=$(git log $LATEST_TAG..HEAD --pretty=format:"- %s")
-          fi
+          # Reuse the release-boundary range computed in "Determine version bump" (tag-independent).
+          ENTRIES=$(cat /tmp/release_entries.md)
 
           DATE=$(date +%Y-%m-%d)
           {
@@ -315,16 +327,10 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         id: changelog
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-
-          if [ -z "$LATEST_TAG" ]; then
-            COMMITS=$(git log --pretty=format:"- %s" HEAD)
-          else
-            COMMITS=$(git log $LATEST_TAG..HEAD --pretty=format:"- %s")
-          fi
-
+          # Reuse the entries computed on main. The earlier `git describe HEAD^` ran here while
+          # checked out on the `upm` branch (after the tag step), so it never saw main's history.
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMITS" >> $GITHUB_OUTPUT
+          cat /tmp/release_entries.md >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release


### PR DESCRIPTION
Fixes the release auto-versioner, which bumped **major on every release** (`1.20.0 → 2.0.0 → 3.0.0`) even for non-breaking PRs.

## Root cause
Release tags are created on the orphan `upm` branch (root-layout publish branch), which is **not reachable from `main`**. So in the publish job (checked out on `main`):
1. `git describe --tags --abbrev=0` finds no reachable tag → falls back to `v0.0.0`.
2. `git log v0.0.0..HEAD` errors (`v0.0.0` doesn't exist) → the `|| git log` fallback scans the **entire repo history**.
3. That history still contains the 2.0 `feat!:`/`BREAKING CHANGE:` commits → `BUMP=major` every single time.

Live proof: PR #23 was `refactor`+`chore` only, yet bumped `2.0.0 → 3.0.0`.

A second latent bug: `Generate changelog` ran `git describe HEAD^` **after** the job had `git checkout upm`, so it never saw `main`'s history regardless.

## Fix
- **Tag-independent release boundary:** use the last `chore: bump version to …` commit on `main` (always reachable) as the range start. First-ever release (no such commit) still scans all history.
- Compute the changelog/release-note subjects **once on `main`** and stash them in a temp file; the later `upm`-checked-out steps reuse it instead of re-deriving the range in the wrong branch context.
- Housekeeping-type bump now inspects files changed **in the range** (`git log --name-only`) rather than a tag diff.

Tagging on `upm` (for `#vX.Y.Z` root-layout installs) is unchanged — version detection simply no longer depends on tag reachability.

## Effect on merge order
- Merging **this** PR (`ci:` only, no `.cs`/`package.json`) ⇒ `BUMP=none` ⇒ **no release** (correct).
- Then merging #24 (`fix:`) ⇒ range = last bump (`3.0.0`)..HEAD ⇒ **patch ⇒ 3.0.1** (correct).

Merge this **before** #24.

## Note on current version
`main` is already at `3.0.0` (erroneously bumped). Recommend accepting it and letting future fixes continue from there (`3.0.1`, …) — rolling back a published `v3.0.0` tag is messier than it's worth. Your call.

Validated: YAML structurally checked; no remaining `git describe`/`LATEST_TAG` logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI versioning logic but directly controls published package versions and release notes; a wrong boundary could skip releases or mis-bump until fixed.
> 
> **Overview**
> Fixes the **UPM publish workflow** so semver bumps and release notes only consider commits **since the last release on `main`**, instead of repeatedly scanning unreachable tags or full history.
> 
> **Version bump range** no longer uses `git describe` / `LATEST_TAG..HEAD` (tags live on orphan `upm`, invisible from `main`). It now starts at the latest `chore: bump version to` commit on `main`, or all of `HEAD` on the first release. Conventional-commit bump rules and housekeeping-only patch detection use that same `RANGE`; patch eligibility for `chore`/`ci`/etc. checks files touched **in the range** via `git log --name-only`, not a tag diff.
> 
> **Changelog / GitHub release body** subjects are built once on `main` into `/tmp/release_entries.md` and reused when prepending the in-package `CHANGELOG` and in **Generate changelog**—avoiding a second range computation after checkout on `upm`, which previously used `git describe HEAD^` and missed `main` history.
> 
> Tagging on `upm` is unchanged; only how the next version and notes are computed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119dca827c096d34cf8b2c8aacfc24f30798c5d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->