### PR TITLE
ci: fix changelog heredoc delimiter (release notes step)

### DIFF
--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -158,8 +158,10 @@ jobs:
 
           # Subjects for the changelog / release notes, computed once here (on main) and reused by
           # later steps via this file — later steps run while checked out on the `upm` branch, where
-          # re-deriving the range would be wrong.
-          git log $RANGE --pretty=format:"- %s" > /tmp/release_entries.md
+          # re-deriving the range would be wrong. Use tformat (trailing newline after every entry,
+          # including the last) so the GITHUB_OUTPUT heredoc in "Generate changelog" finds its EOF
+          # delimiter on its own line; plain format: omits the final newline and breaks it.
+          git log $RANGE --pretty=tformat:"- %s" > /tmp/release_entries.md
 
           # Strict Conventional Commits only — no bare ^break/^feature/^bugfix aliases
           # (they mis-bump), and no catch-all "any change -> patch" fallback.


### PR DESCRIPTION
Follow-up to #25. The `Generate changelog` step failed on the v3.0.1 release with `Matching delimiter not found 'EOF'`, skipping **Create GitHub Release** (the tag + upm publish succeeded, so the package is released — only the Release page was missing).

**Cause:** `git log --pretty=format:` writes no trailing newline, so `cat /tmp/release_entries.md >> $GITHUB_OUTPUT` placed the last entry on the same line as the `EOF` delimiter.

**Fix:** use `--pretty=tformat:` (newline after every entry, including the last).

`ci:`-only change → no version bump on merge. The missing v3.0.1 GitHub Release will be created manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to release note formatting; no runtime, auth, or package code impact.
> 
> **Overview**
> Fixes the **Generate changelog** step in the UPM publish workflow so GitHub Actions can parse the `changelog<<EOF` block written to `GITHUB_OUTPUT`.
> 
> The **Determine version bump** step now writes `/tmp/release_entries.md` with `git log --pretty=tformat:` instead of `format:`. **`tformat`** adds a trailing newline after every line, including the last commit subject, so the closing `EOF` delimiter sits on its own line. With **`format`**, the final entry was appended on the same line as `EOF`, which triggered `Matching delimiter not found 'EOF'` and skipped **Create GitHub Release** (as on v3.0.1) while tag/upm publish still succeeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2e5a3196543e0d7ee6448c7bd57d7d2b2c76ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->