### PR TITLE
test: cover GetBounds + world/self group rotation

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/TransformUtilsTests.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/TransformUtilsTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using TransformHandles.Utils;
+using UnityEngine;
+
+namespace TransformHandles.Tests.Editor
+{
+    public class TransformUtilsTests
+    {
+        private readonly List<GameObject> _spawned = new List<GameObject>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var go in _spawned)
+            {
+                if (go != null) Object.DestroyImmediate(go);
+            }
+            _spawned.Clear();
+        }
+
+        private GameObject NewEmpty(string name, Vector3 position)
+        {
+            var go = new GameObject(name) { transform = { position = position } };
+            _spawned.Add(go);
+            return go;
+        }
+
+        private GameObject NewCube(string name, Vector3 position, Transform parent = null)
+        {
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = name;
+            if (parent != null) go.transform.SetParent(parent);
+            go.transform.position = position;
+            _spawned.Add(go);
+            return go;
+        }
+
+        [Test]
+        public void GetBounds_no_renderers_returns_zero_size_at_position_without_nan()
+        {
+            // Regression: the old implementation divided by renderers.Length (== 0) and produced
+            // NaN bounds for renderer-less targets, poisoning pivot/center placement.
+            var empty = NewEmpty("empty", new Vector3(3f, 4f, 5f));
+
+            var bounds = empty.transform.GetBounds();
+
+            Assert.AreEqual(new Vector3(3f, 4f, 5f), bounds.center);
+            Assert.AreEqual(Vector3.zero, bounds.size);
+            Assert.IsFalse(float.IsNaN(bounds.center.x) || float.IsNaN(bounds.size.x), "bounds must not be NaN");
+        }
+
+        [Test]
+        public void GetBounds_single_renderer_matches_renderer_bounds()
+        {
+            var cube = NewCube("cube", new Vector3(2f, 0f, 0f));
+            var expected = cube.GetComponent<Renderer>().bounds;
+
+            var bounds = cube.transform.GetBounds();
+
+            Assert.That(Vector3.Distance(bounds.center, expected.center), Is.LessThan(1e-4f));
+            Assert.That(Vector3.Distance(bounds.size, expected.size), Is.LessThan(1e-4f));
+        }
+
+        [Test]
+        public void GetBounds_multiple_renderers_encapsulates_all()
+        {
+            // Two unit cubes 4 units apart on X. The combined AABB must contain both and span the
+            // full extent (size.x == 5), not the average of the two (which would be ~1).
+            var root = NewEmpty("root", Vector3.zero);
+            var left = NewCube("left", new Vector3(-2f, 0f, 0f), root.transform);
+            var right = NewCube("right", new Vector3(2f, 0f, 0f), root.transform);
+
+            var bounds = root.transform.GetBounds();
+
+            Assert.That(Vector3.Distance(bounds.center, Vector3.zero), Is.LessThan(1e-4f));
+            Assert.That(bounds.size.x, Is.EqualTo(5f).Within(1e-3f));
+            Assert.IsTrue(bounds.Contains(left.GetComponent<Renderer>().bounds.center));
+            Assert.IsTrue(bounds.Contains(right.GetComponent<Renderer>().bounds.center));
+        }
+    }
+}

--- a/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/TransformUtilsTests.cs.meta
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/TransformUtilsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f18c19cab0f4d8e85feee83d86d76c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.orkunmanap.runtime-transform-handles/Tests/Runtime/TransformGroupTests.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Tests/Runtime/TransformGroupTests.cs
@@ -38,6 +38,14 @@ namespace TransformHandles.Tests
 
         private TransformGroup NewGroup() => new TransformGroup(null, _handle);
 
+        private Ghost NewGhost(Vector3 position)
+        {
+            // Ghost.Initialize touches the manager singleton, so it is deliberately NOT called;
+            // UpdateRotations only reads GroupGhost.transform.position.
+            var go = NewObject("ghost", position);
+            return go.AddComponent<Ghost>();
+        }
+
         [Test]
         public void AddTransform_accepts_unrelated_targets()
         {
@@ -121,6 +129,61 @@ namespace TransformHandles.Tests
 
             Assert.IsFalse(group.RemoveTransform(a), "still has one member");
             Assert.IsTrue(group.RemoveTransform(b), "now empty");
+        }
+
+        [Test]
+        public void UpdateRotations_self_space_rotates_member_around_ghost()
+        {
+            _handle.space = Space.Self;
+            var ghost = NewGhost(Vector3.zero);
+            var group = new TransformGroup(ghost, _handle);
+            var target = NewObject("t", new Vector3(1f, 0f, 0f)).transform;
+            group.AddTransform(target);
+
+            // +90 deg about Y maps the +X axis to -Z.
+            var delta = Quaternion.Euler(0f, 90f, 0f);
+            group.UpdateRotations(delta);
+
+            Assert.That(Vector3.Distance(target.position, new Vector3(0f, 0f, -1f)), Is.LessThan(1e-4f));
+            Assert.That(Quaternion.Angle(target.rotation, delta), Is.LessThan(0.01f));
+        }
+
+        [Test]
+        public void UpdateRotations_world_space_uses_true_axis_angle()
+        {
+            // Regression for the world-space path: a 120 deg rotation about (1,1,1) cyclically
+            // permutes the axes (X->Y), so a member at (1,0,0) must land at (0,1,0). The old code
+            // derived the axis/angle from rotationChange.eulerAngles and its magnitude, which is not
+            // a valid axis/angle decomposition and lands the point somewhere else for this delta.
+            _handle.space = Space.World;
+            var ghost = NewGhost(Vector3.zero);
+            var group = new TransformGroup(ghost, _handle);
+            var target = NewObject("t", new Vector3(1f, 0f, 0f)).transform;
+            group.AddTransform(target);
+
+            var delta = Quaternion.AngleAxis(120f, Vector3.one.normalized);
+            group.UpdateRotations(delta);
+
+            Assert.That(Vector3.Distance(target.position, new Vector3(0f, 1f, 0f)), Is.LessThan(1e-3f));
+            Assert.That(Quaternion.Angle(target.rotation, delta), Is.LessThan(0.05f));
+        }
+
+        [Test]
+        public void UpdateRotations_world_space_rotates_all_members_around_ghost()
+        {
+            _handle.space = Space.World;
+            var ghost = NewGhost(Vector3.zero);
+            var group = new TransformGroup(ghost, _handle);
+            var a = NewObject("a", new Vector3(1f, 0f, 0f)).transform;
+            var b = NewObject("b", new Vector3(0f, 0f, 1f)).transform;
+            group.AddTransform(a);
+            group.AddTransform(b);
+
+            // +90 deg about Y: (1,0,0)->(0,0,-1), (0,0,1)->(1,0,0).
+            group.UpdateRotations(Quaternion.Euler(0f, 90f, 0f));
+
+            Assert.That(Vector3.Distance(a.position, new Vector3(0f, 0f, -1f)), Is.LessThan(1e-4f));
+            Assert.That(Vector3.Distance(b.position, new Vector3(1f, 0f, 0f)), Is.LessThan(1e-4f));
         }
     }
 }


### PR DESCRIPTION
Addresses the **Testing** dimension from #26 (weakest scorecard area, 5.5/10) and locks in the #24 correctness fixes.

## Added
**EditMode — `TransformUtilsTests`** (`GetBounds`):
- zero renderers → zero-size bounds at the transform position, **no NaN** (the old divide-by-count bug)
- single renderer → passthrough
- multiple renderers → `Encapsulate` (combined extent, not the average)

**PlayMode — `TransformGroupTests`** (`UpdateRotations`):
- Self-space: member rotates around the ghost
- World-space: `120°`-about-`(1,1,1)` case (X→Y) — **fails on the old `eulerAngles`-as-axis formula**, passes with `ToAngleAxis`
- World-space multi-target

All assertions target the **current (fixed) code**, so they pass on main and guard against regressions.

## Note
`test:` + test `.cs` changes ⇒ the housekeeping bump clause will patch-bump on merge (**3.0.2**). Harmless. Refining the clause to ignore `Tests/**` and `Samples~/**` is tracked in #26 (CI hardening).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or API modifications.
> 
> **Overview**
> Adds **EditMode** coverage for `Transform.GetBounds()`: renderer-less targets get zero-size bounds at the transform position (no NaN), a single renderer matches its bounds, and multiple child renderers use combined **Encapsulate** extent—not an average.
> 
> Extends **PlayMode** `TransformGroupTests` with a lightweight `Ghost` helper and **`UpdateRotations`** cases for self-space orbit about the ghost, world-space axis/angle (including the `120°` about `(1,1,1)` regression that broke under euler-based decomposition), and multi-member world rotation.
> 
> These tests lock in prior #24 fixes; production behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd4bccfc7ec010ca481c944a15d86dbcd9fe8fe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->