### PR TITLE
ci: harden publish (bump filter, concurrency, dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keep CI action versions current (game-ci, actions/*, softprops/*). Grouped so a single PR
+  # carries all minor/patch action bumps instead of one PR per action.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -12,6 +12,13 @@ permissions:
   checks: write
   pull-requests: write
 
+# Serialize per ref so two main pushes can't run the publish/bump/tag steps concurrently
+# (which previously raced on the version-bump commit and tag). Stale PR runs are cancelled;
+# main runs queue (never cancelled mid-release) so an in-flight release always completes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # UPM-spec gate: manifest + required files + asmdef sanity. No Unity license needed,
   # so it runs fast on every PR and enforces the package floor going forward.
@@ -175,8 +182,12 @@ jobs:
           elif echo "$COMMITS" | grep -qiE "^(fix|perf|refactor)(\(.+\))?:"; then
             BUMP="patch"
           elif echo "$COMMITS" | grep -qiE "^(docs|style|chore|ci|test|build)(\(.+\))?:"; then
-            # Housekeeping types only bump when actual code/manifest changed in the range.
-            if git log $RANGE --name-only --pretty=format: | sort -u | grep -qE "\.cs$|package\.json$"; then
+            # Housekeeping types only bump when SHIPPING code/manifest changed in the range.
+            # Test- or sample-only changes (Tests/, Samples~/) don't affect consumers, so they
+            # must not trigger a release (otherwise adding a test cuts a pointless version).
+            if git log $RANGE --name-only --pretty=format: | sort -u \
+                 | grep -vE "/Tests/|/Samples~/" \
+                 | grep -qE "\.cs$|package\.json$"; then
               BUMP="patch"
             fi
           fi


### PR DESCRIPTION
Addresses the CI-hardening items from #26.

## Changes
1. **Bump filter ignores non-shipping paths.** The housekeeping bump clause now excludes `Tests/` and `Samples~/` before checking for `.cs`/`package.json`, so test- or sample-only commits no longer cut a release. Verified against history: the #28 (test-only) range now yields `BUMP=none`; the #24 (runtime) range still bumps.
2. **Publish concurrency guard.** `concurrency: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress` only for PRs. Main publish runs **queue** (never cancelled mid-release); stale PR runs cancel. Prevents the two-concurrent-main-publish race seen earlier.
3. **Dependabot** for `github-actions` (grouped, weekly).

`ci:`-only + non-shipping paths ⇒ with the new filter this PR itself triggers **no release** on merge.

Validated: YAML parses; bump-filter logic checked against real commit ranges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and Dependabot config only; no runtime package or auth logic changes.
> 
> **Overview**
> Hardens **UPM publish** automation so releases are less noisy and less racy.
> 
> **`publish-upm.yml`** adds **per-ref concurrency**: main publish runs queue (no mid-release cancel); PR runs cancel superseded ones. The **housekeeping semver bump** path now ignores paths under `Tests/` and `Samples~/` before checking for shipping `.cs` / `package.json`, so test- or sample-only `ci:`/`chore:`/`test:` commits no longer cut a consumer release.
> 
> Adds **`.github/dependabot.yml`** for weekly, **grouped** `github-actions` updates at repo root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f10ef94042a9f86ccd1d45b263d9b7e56990c1b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->