### PR TITLE
docs: fix quick-start logging handle.target (pivot, not object)

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/README.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/README.md
@@ -55,8 +55,10 @@ public class SimpleExample : MonoBehaviour
     void CreateHandleForObject(Transform target)
     {
         Handle handle = TransformHandleManager.Instance.CreateHandle(target);
-        handle.OnInteractionStartEvent += h => Debug.Log("Started: " + h.target.name);
-        handle.OnInteractionEndEvent   += h => Debug.Log("Finished: " + h.target.name);
+        // Note: handle.target is the internal manipulation pivot (the group's ghost), not your
+        // object. Capture your own `target` reference for anything object-specific.
+        handle.OnInteractionStartEvent += _ => Debug.Log("Started: " + target.name);
+        handle.OnInteractionEndEvent   += _ => Debug.Log("Finished: " + target.name);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -107,19 +107,10 @@ public class SimpleExample : MonoBehaviour
         // Create a handle for a single object
         Handle handle = _manager.CreateHandle(target);
 
-        // Subscribe to events
-        handle.OnInteractionStartEvent += OnHandleStart;
-        handle.OnInteractionEndEvent += OnHandleEnd;
-    }
-
-    void OnHandleStart(Handle handle)
-    {
-        Debug.Log("Started manipulating: " + handle.target.name);
-    }
-
-    void OnHandleEnd(Handle handle)
-    {
-        Debug.Log("Finished manipulating: " + handle.target.name);
+        // Subscribe to events. Note: handle.target is the internal manipulation pivot (the
+        // group's ghost), not your object — capture your own `target` for anything object-specific.
+        handle.OnInteractionStartEvent += _ => Debug.Log("Started manipulating: " + target.name);
+        handle.OnInteractionEndEvent   += _ => Debug.Log("Finished manipulating: " + target.name);
     }
 }
 ```


### PR DESCRIPTION
From #26 (doc accuracy). `handle.target` is the internal manipulation pivot — `TransformHandleManager` calls `handle.Enable(ghost.transform)` — so the quick-start's `handle.target.name` logged the **ghost pivot's** name, not the user's object, in both the package and root README.

Fixed both to capture the caller's own `target` in the event closures, with a note that `handle.target` is the pivot. `docs:` only → no release.

(Migration-guide `PreserveScaleOnScreen` naming from the scorecard checked out fine — the method *is* named `PreserveScaleOnScreen`; no change needed.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to README examples; no runtime, API, or behavior changes.
> 
> **Overview**
> Corrects **quick-start** examples in the **package** and **root** README so interaction event handlers no longer log `handle.target.name`.
> 
> **`handle.target`** is documented as the internal manipulation pivot (the group **ghost** from `TransformHandleManager`), not the user’s object. Examples now close over the caller’s **`target`** and use `_ =>` lambdas, with a short inline note explaining the distinction. The root README drops the separate `OnHandleStart` / `OnHandleEnd` methods in favor of the same inline pattern as the package doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41df77a1aeb777c1bf3cfe13068aaeb607bcab4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->