### PR TITLE
ci: min-API lint for the Unity 2021.3 floor

### DIFF
--- a/.github/workflows/min-api-lint.yml
+++ b/.github/workflows/min-api-lint.yml
@@ -1,0 +1,63 @@
+name: Min-API Lint
+
+# Guards the declared minimum Unity version (package.json `unity` = 2021.3). The dev project and
+# the Unity test job both run on Unity 6000.3, so they cannot catch APIs that fail to compile on an
+# early 2021.3.x consumer. This license-free static check flags such APIs when they are used WITHOUT
+# a version guard. It is a heuristic (not a real 2021.3 compile), focused on the Find*ByType family
+# that previously broke the floor; guarded usage (#if UNITY_..._OR_NEWER ... #else FindObjectOfType)
+# is allowed.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "Packages/**/*.cs"
+      - ".github/workflows/min-api-lint.yml"
+  pull_request:
+    paths:
+      - "Packages/**/*.cs"
+      - ".github/workflows/min-api-lint.yml"
+
+jobs:
+  min-api-lint:
+    name: Min-API lint (Unity 2021.3 floor)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Scan for unguarded post-2021.3 APIs
+        run: |
+          set -uo pipefail
+          PKG="Packages/com.orkunmanap.runtime-transform-handles"
+
+          # APIs introduced after 2021.3.0 (Find*ByType: 2021.3.18f1 / 2022.2). Add more here as
+          # the floor concern grows. FindObjectOfType (the pre-2021.3 API) is intentionally allowed.
+          DENY='FindAnyObjectByType|FindFirstObjectByType|FindObjectsByType'
+
+          # awk tracks #if/#elif/#else/#endif nesting and marks a level "version-guarded" when its
+          # condition mentions UNITY_<year> or *_OR_NEWER. A denied API is reported only when it sits
+          # outside every version-guarded region (comment-only lines are ignored).
+          HITS=$(while IFS= read -r -d '' f; do
+            awk -v deny="$DENY" -v file="$f" '
+              function isver(s){ return (s ~ /UNITY_[0-9]/ || s ~ /OR_NEWER/) }
+              /^[ \t]*#[ \t]*if/    { depth++; g[depth]=isver($0)?1:0; next }
+              /^[ \t]*#[ \t]*elif/  { if(depth>0 && isver($0)) g[depth]=1; next }
+              /^[ \t]*#[ \t]*else/  { next }
+              /^[ \t]*#[ \t]*endif/ { if(depth>0) depth--; next }
+              {
+                ing=0; for(i=1;i<=depth;i++) if(g[i]) ing=1
+                if(ing==0 && $0 ~ ("(" deny ")") && $0 !~ /^[ \t]*\/\//)
+                  printf "%s:%d:%s\n", file, NR, $0
+              }
+            ' "$f"
+          done < <(find "$PKG" -name '*.cs' -print0))
+
+          if [ -n "$HITS" ]; then
+            echo "::error::Unguarded post-2021.3 API usage (wrap in '#if UNITY_2023_1_OR_NEWER ... #else <FindObjectOfType> #endif'):"
+            echo "$HITS"
+            exit 1
+          fi
+
+          echo "Min-API lint passed: no unguarded post-2021.3 Find*ByType usage."


### PR DESCRIPTION
From #26 (floor verification). A true 2021.3 test matrix isn't possible here — the dev project is Unity 6000.3 and 2021.3 can't open a newer-editor project. This adds a **license-free static lint** instead, targeting the exact regression class that bit the floor before (issue #11 / `FindAnyObjectByType`).

## What it does
Flags `FindAnyObjectByType` / `FindFirstObjectByType` / `FindObjectsByType` (added 2021.3.18f1 / 2022.2) when used **without** a version guard. An awk pass tracks `#if/#elif/#else/#endif` nesting and marks a level version-guarded when its condition mentions `UNITY_<year>` / `*_OR_NEWER`, so the existing guarded usages are allowed:
- `Singleton.cs` `FindFirstObjectByType` (behind `#if UNITY_2023_1_OR_NEWER` / `#else FindObjectOfType`)
- `HandleDemo.cs` `FindAnyObjectByType` (same guard)

Runs on PRs/pushes touching `Packages/**/*.cs`. No Unity license/image.

## Verified locally
- Current sources → **pass** (both guarded uses ignored)
- Unguarded control line → **caught**

Heuristic, not a full compile (tradeoff chosen over a heavy minimal-2021.3 project). `ci:` only → no release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only heuristic; no runtime or package source behavior changes.
> 
> **Overview**
> Adds a **license-free GitHub Actions** job that enforces the package’s declared **Unity 2021.3** minimum when the repo’s dev/tests run on **6000.3** and cannot compile on early 2021.3 consumers.
> 
> On pushes/PRs that touch `Packages/**/*.cs`, an **awk-based scan** of `Packages/com.orkunmanap.runtime-transform-handles` fails CI if `FindAnyObjectByType`, `FindFirstObjectByType`, or `FindObjectsByType` appear **outside** `#if` regions whose conditions reference `UNITY_<year>` or `*_OR_NEWER`—so existing guarded fallbacks to `FindObjectOfType` stay allowed. The deny list is documented as extensible for future floor regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8f4b54906a8769a30d00427cb17fc56f8b204c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->