### PR TITLE
fix: framerate-independent global scale speed

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleGlobal.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleGlobal.cs
@@ -8,7 +8,9 @@ namespace TransformHandles
     /// </summary>
     public class ScaleGlobal : HandleBase
     {
-        private const float MouseSensitivity = 2f;
+        // Scale delta per pixel dragged. Chosen to match the previous feel at 60 fps
+        // (the old code used 2f * Time.deltaTime, i.e. ~2/60 per pixel at 60 fps).
+        private const float MouseSensitivity = 0.0333f;
 
         [SerializeField] private Color defaultColor;
         [SerializeField] private MeshRenderer cubeMeshRenderer;
@@ -37,7 +39,10 @@ namespace TransformHandles
         public override void Interact(Vector3 previousPosition)
         {
             var mouseVector = (Vector3)InputWrapper.MousePosition - previousPosition;
-            var d = (mouseVector.x + mouseVector.y) * Time.deltaTime * MouseSensitivity;
+            // mouseVector is the per-frame pixel delta; the total scale change should depend on how
+            // far the mouse moved, not on the frame rate. Multiplying by Time.deltaTime made scaling
+            // speed framerate-dependent (higher fps -> smaller dt -> slower scaling). Drop it.
+            var d = (mouseVector.x + mouseVector.y) * MouseSensitivity;
             delta += d;
             ParentHandle.target.localScale = _startScale + Vector3.Scale(_startScale, _axis) * delta;
 


### PR DESCRIPTION
From #26 (P2). `ScaleGlobal.Interact` multiplied the per-frame mouse pixel delta by `Time.deltaTime`, so uniform-scale speed depended on the frame rate (higher fps → smaller dt → slower scaling for the same drag).

**Fix:** drop `Time.deltaTime` so the scale delta depends only on drag distance. `MouseSensitivity` retuned `2f → 0.0333f` to preserve the previous feel at 60 fps (old effective rate was `2 * (1/60) ≈ 0.0333` per pixel).

⚠️ Constant is feel-matched to 60 fps but **not play-tested here** — quick manual check of the global (center cube) scale drag recommended; the behavior is now correct (framerate-independent) regardless of the exact constant.

`fix:` → patches to 3.0.3 on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small interaction tweak in one scale handle; feel is constant-matched to 60 fps but worth a quick manual drag check.
> 
> **Overview**
> Fixes **framerate-dependent** uniform scaling on the global (center cube) scale handle in `ScaleGlobal.Interact`.
> 
> The drag delta was incorrectly multiplied by `Time.deltaTime` on top of per-frame mouse pixel movement, so higher FPS made scaling slower for the same drag. **`Time.deltaTime` is removed** so scale change tracks drag distance only. **`MouseSensitivity`** is retuned from `2f` to `0.0333f` to approximate the old feel at 60 fps (`2 * deltaTime` per pixel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dabf758029a26dd2ebec28e23b4100321465c03d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->