### PR TITLE
test: cover TransformGroup apply paths (positions + scales)

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/Tests/Runtime/TransformGroupTests.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Tests/Runtime/TransformGroupTests.cs
@@ -46,6 +46,15 @@ namespace TransformHandles.Tests
             return go.AddComponent<Ghost>();
         }
 
+        private GameObject NewCube(string name, Vector3 position)
+        {
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = name;
+            go.transform.position = position;
+            _spawned.Add(go);
+            return go;
+        }
+
         [Test]
         public void AddTransform_accepts_unrelated_targets()
         {
@@ -184,6 +193,52 @@ namespace TransformHandles.Tests
 
             Assert.That(Vector3.Distance(a.position, new Vector3(0f, 0f, -1f)), Is.LessThan(1e-4f));
             Assert.That(Vector3.Distance(b.position, new Vector3(1f, 0f, 0f)), Is.LessThan(1e-4f));
+        }
+
+        [Test]
+        public void UpdatePositions_offsets_all_members_by_the_delta()
+        {
+            var group = NewGroup();
+            var a = NewObject("a", new Vector3(1f, 2f, 3f)).transform;
+            var b = NewObject("b", new Vector3(-4f, 0f, 0f)).transform;
+            group.AddTransform(a);
+            group.AddTransform(b);
+
+            group.UpdatePositions(new Vector3(0f, 5f, 0f));
+
+            Assert.That(Vector3.Distance(a.position, new Vector3(1f, 7f, 3f)), Is.LessThan(1e-4f));
+            Assert.That(Vector3.Distance(b.position, new Vector3(-4f, 5f, 0f)), Is.LessThan(1e-4f));
+        }
+
+        [Test]
+        public void UpdateScales_pivot_origin_adds_to_local_scale_and_keeps_position()
+        {
+            var group = NewGroup();
+            group.IsOriginOnCenter = false;
+            var t = NewObject("t", new Vector3(2f, 0f, 0f)).transform; // no renderer -> pivot path
+            group.AddTransform(t);
+
+            group.UpdateScales(new Vector3(0.5f, 0.5f, 0.5f));
+
+            Assert.That(Vector3.Distance(t.localScale, new Vector3(1.5f, 1.5f, 1.5f)), Is.LessThan(1e-4f));
+            Assert.That(Vector3.Distance(t.position, new Vector3(2f, 0f, 0f)), Is.LessThan(1e-4f));
+        }
+
+        [Test]
+        public void UpdateScales_center_origin_scales_centered_cube_without_moving_it()
+        {
+            // A primitive cube's mesh is centered on its transform, so center-origin scaling needs
+            // no position compensation — exercises the IsOriginOnCenter + renderer branch and
+            // confirms a centered object stays put while its scale grows.
+            var group = NewGroup();
+            group.IsOriginOnCenter = true;
+            var cube = NewCube("cube", new Vector3(3f, 0f, 0f)).transform; // has MeshRenderer
+            group.AddTransform(cube);
+
+            group.UpdateScales(new Vector3(1f, 1f, 1f));
+
+            Assert.That(Vector3.Distance(cube.localScale, new Vector3(2f, 2f, 2f)), Is.LessThan(1e-3f));
+            Assert.That(Vector3.Distance(cube.position, new Vector3(3f, 0f, 0f)), Is.LessThan(1e-3f));
         }
     }
 }


### PR DESCRIPTION
From #26 (test coverage). Adds PlayMode coverage for the previously-untested multi-target apply methods in `TransformGroup`:
- `UpdatePositions` offsets every member by the delta
- `UpdateScales` pivot-origin: adds to `localScale`, leaves position
- `UpdateScales` center-origin: exercises the `IsOriginOnCenter` + renderer branch (scales a centered cube in place)

`test:` only + under `Tests/` → excluded from the bump filter (#29) → **no release** on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes under Tests/ with no production or runtime behavior changes.
> 
> **Overview**
> Adds **PlayMode tests** in `TransformGroupTests` for multi-target apply behavior on `TransformGroup` that was not covered before (rotation tests already existed).
> 
> New coverage checks that **`UpdatePositions`** applies the same world delta to every group member, and that **`UpdateScales`** behaves correctly for **pivot-origin** targets (adds to `localScale`, position unchanged) and **center-origin** targets with a renderer (primitive cube stays in place while scale increases). A small **`NewCube`** helper creates a primitive cube with a `MeshRenderer` for the center-origin case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5509a148599c2590b96fb4db3c5914c68088a4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->