### PR TITLE
ci: harden release flow against main advancing during a publish run

### DIFF
--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -205,12 +205,15 @@ jobs:
               # Package the bump commit's tree, NOT HEAD — commits that landed after the interrupted
               # publish must not ship under this recovered tag (they release on a later run).
               RELEASE_REF="$RANGE_START"
-              # Recover this version's notes from its committed CHANGELOG section.
-              awk -v h="## [$CURRENT]" '
-                index($0, h) == 1 { grab = 1; next }
-                grab && /^## \[/ { exit }
-                grab && /^- /    { print }
-              ' "$CHANGELOG" > /tmp/release_entries.md
+              # Recover this version's notes from the CHANGELOG at the bump commit (the same ref we
+              # package from), so the GitHub release notes match the shipped in-package changelog even
+              # if main's CHANGELOG changed after the bump.
+              git show "$RANGE_START:$CHANGELOG" \
+                | awk -v h="## [$CURRENT]" '
+                    index($0, h) == 1 { grab = 1; next }
+                    grab && /^## \[/ { exit }
+                    grab && /^- /    { print }
+                  ' > /tmp/release_entries.md
               return 0
             fi
 

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -138,6 +138,8 @@ jobs:
 
       - name: Prepare release and push
         id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # actions/checkout pins this job to the triggering commit (github.sha). The job is serialized
         # by the concurrency group, but while it waited on the ~5-min test job (or queued behind another
         # release) main can advance, and it can advance again between computing the bump and pushing it.
@@ -199,9 +201,28 @@ jobs:
             fi
             echo "Bump type: $BUMP"
 
+            RECOVER="false"
             if [ "$BUMP" = "none" ]; then
-              SKIP="true"
               NEW_VERSION="$CURRENT"
+              # bump=none normally means "already released, nothing to do". But if an earlier run pushed
+              # this version's bump commit and then died before tagging/releasing it, main sits at a
+              # version with no GitHub release and no future run would ever finish it (the bump commit
+              # makes the range empty forever). Detect that — a bump commit exists for CURRENT but its
+              # release does not — and complete the publish instead of skipping it. No new commit to push.
+              if [ -n "$RANGE_START" ] \
+                 && ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v$CURRENT" >/dev/null 2>&1; then
+                echo "v$CURRENT was bumped on main but has no release; completing the publish."
+                SKIP="false"
+                RECOVER="true"
+                # Recover this version's notes from its committed CHANGELOG section.
+                awk -v h="## [$CURRENT]" '
+                  index($0, h) == 1 { grab = 1; next }
+                  grab && /^## \[/ { exit }
+                  grab && /^- /    { print }
+                ' "$CHANGELOG" > /tmp/release_entries.md
+              else
+                SKIP="true"
+              fi
               return 0
             fi
             SKIP="false"
@@ -247,7 +268,12 @@ jobs:
           for attempt in 1 2 3 4 5; do
             prepare
             if [ "$SKIP" = "true" ]; then
-              echo "Nothing to release (no bump in range); skipping."
+              echo "Nothing to release (already published, or no bump in range); skipping."
+              break
+            fi
+            if [ "$RECOVER" = "true" ]; then
+              echo "Completing an incomplete publish of v$NEW_VERSION (nothing to push)."
+              pushed=1
               break
             fi
             if git push origin main; then pushed=1; break; fi
@@ -320,10 +346,16 @@ jobs:
 
           git checkout upm
 
-          git tag -a $VERSION -m "Release $VERSION"
-          git push origin $VERSION
-
-          echo "Tagged version: $VERSION"
+          # Idempotent: a recovery run (completing an earlier interrupted publish) may reach here with
+          # the tag already pushed. Only create + push it when it is missing, so the non-force tag push
+          # never fails the job on an existing tag.
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q "refs/tags/$VERSION"; then
+            echo "Tag $VERSION already exists on origin; leaving it."
+          else
+            git tag -a "$VERSION" -m "Release $VERSION"
+            git push origin "$VERSION"
+            echo "Tagged version: $VERSION"
+          fi
 
       - name: Generate changelog
         if: steps.release.outputs.skip != 'true'

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -284,7 +284,21 @@ jobs:
 
           git add "$PACKAGE_PATH/package.json" "$PACKAGE_PATH/CHANGELOG.md"
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]" || echo "No changes to commit"
-          git push origin main
+
+          # main can advance between this run's checkout and now (e.g. another PR merged while this
+          # run was queued behind the concurrency gate), which makes a plain push fail with
+          # non-fast-forward. Rebase the bump onto the latest main and retry so the release lands.
+          pushed=0
+          for attempt in 1 2 3 4 5; do
+            if git push origin main; then pushed=1; break; fi
+            echo "push rejected (attempt $attempt); rebasing onto origin/main and retrying"
+            git pull --rebase origin main || true
+            sleep $((attempt * 3))
+          done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::error::Failed to push the version bump after 5 attempts."
+            exit 1
+          fi
 
       - name: Create/Update UPM branch
         if: steps.version.outputs.skip != 'true'

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -131,199 +131,152 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sync to latest main
-        # The publish job is serialized by the concurrency group, but actions/checkout pins to the
-        # triggering commit (github.sha). While this run waited on the ~5-min test job (or queued
-        # behind another release), main may have advanced. Compute the version against the REAL
-        # latest main so that a release another run already landed is seen as "nothing to bump" and
-        # this run skips cleanly, instead of recomputing a stale/duplicate version that then collides
-        # on push (rebase conflict) or on the non-force tag push. The retry loop in "Commit version
-        # bump" only has to cover main advancing during this job's own (seconds-long) window.
-        run: |
-          git fetch origin main
-          git checkout -B main origin/main
-          echo "Synced to origin/main: $(git rev-parse --short HEAD)"
-
-      - name: Get current version
-        id: current
-        run: |
-          VERSION=$(cat Packages/com.orkunmanap.runtime-transform-handles/package.json | jq -r '.version')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Current version: $VERSION"
-
-      - name: Determine version bump
-        id: bump
-        run: |
-          # Release boundary = the last automated version-bump commit on main. Tags are created
-          # on the orphan `upm` branch, which is NOT reachable from main, so `git describe --tags`
-          # found nothing here and the range fell back to the ENTIRE history — re-counting old
-          # BREAKING/feat commits and over-bumping (major) on every release. The bump commit is
-          # always reachable from main, so it is a reliable, tag-independent boundary.
-          RANGE_START=$(git log --grep='^chore: bump version to' --format=%H -n 1 HEAD || true)
-
-          if [ -n "$RANGE_START" ]; then
-            RANGE="$RANGE_START..HEAD"
-            echo "Previous release commit: $RANGE_START"
-          else
-            RANGE="HEAD"
-            echo "No previous bump commit found; treating all history as the first release."
-          fi
-          echo "Commit range: $RANGE"
-
-          # Read FULL commit messages (%B) so `BREAKING CHANGE:` body/footer lines are seen,
-          # not just subjects.
-          COMMITS=$(git log $RANGE --format=%B)
-          echo "Commits in range:"
-          echo "$COMMITS"
-
-          # Subjects for the changelog / release notes, computed once here (on main) and reused by
-          # later steps via this file — later steps run while checked out on the `upm` branch, where
-          # re-deriving the range would be wrong. Use tformat (trailing newline after every entry,
-          # including the last) so the GITHUB_OUTPUT heredoc in "Generate changelog" finds its EOF
-          # delimiter on its own line; plain format: omits the final newline and breaks it.
-          git log $RANGE --pretty=tformat:"- %s" > /tmp/release_entries.md
-
-          # Strict Conventional Commits only — no bare ^break/^feature/^bugfix aliases
-          # (they mis-bump), and no catch-all "any change -> patch" fallback.
-          BUMP="none"
-
-          if echo "$COMMITS" | grep -qE "^BREAKING CHANGE:" \
-             || echo "$COMMITS" | grep -qiE "^[a-z]+(\(.+\))?!:"; then
-            BUMP="major"
-          elif echo "$COMMITS" | grep -qiE "^feat(\(.+\))?:"; then
-            BUMP="minor"
-          elif echo "$COMMITS" | grep -qiE "^(fix|perf|refactor)(\(.+\))?:"; then
-            BUMP="patch"
-          elif echo "$COMMITS" | grep -qiE "^(docs|style|chore|ci|test|build)(\(.+\))?:"; then
-            # Housekeeping types only bump when SHIPPING code/manifest changed in the range.
-            # Test- or sample-only changes (Tests/, Samples~/) don't affect consumers, so they
-            # must not trigger a release (otherwise adding a test cuts a pointless version).
-            if git log $RANGE --name-only --pretty=format: | sort -u \
-                 | grep -vE "/Tests/|/Samples~/" \
-                 | grep -qE "\.cs$|package\.json$"; then
-              BUMP="patch"
-            fi
-          fi
-
-          echo "bump=$BUMP" >> $GITHUB_OUTPUT
-          echo "Bump type: $BUMP"
-
-      - name: Calculate new version
-        id: version
-        run: |
-          CURRENT="${{ steps.current.outputs.version }}"
-          BUMP="${{ steps.bump.outputs.bump }}"
-
-          if [ "$BUMP" = "none" ]; then
-            echo "version=$CURRENT" >> $GITHUB_OUTPUT
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "No version bump needed"
-            exit 0
-          fi
-
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-
-          case $BUMP in
-            major)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
-            minor)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            patch)
-              PATCH=$((PATCH + 1))
-              ;;
-          esac
-
-          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "skip=false" >> $GITHUB_OUTPUT
-          echo "New version: $NEW_VERSION"
-
-      - name: Update package.json version
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
-          PACKAGE_FILE="Packages/com.orkunmanap.runtime-transform-handles/package.json"
-
-          jq ".version = \"$NEW_VERSION\"" $PACKAGE_FILE > tmp.json && mv tmp.json $PACKAGE_FILE
-
-          echo "Updated package.json to version $NEW_VERSION"
-          cat $PACKAGE_FILE
-
-      - name: Prepend release notes into in-package CHANGELOG
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
-          CHANGELOG="Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md"
-
-          # Reuse the release-boundary range computed in "Determine version bump" (tag-independent).
-          ENTRIES=$(cat /tmp/release_entries.md)
-
-          DATE=$(date +%Y-%m-%d)
-          {
-            echo "## [$NEW_VERSION] - $DATE"
-            echo ""
-            echo "$ENTRIES"
-            echo ""
-          } > /tmp/new_entry.md
-
-          if [ -f "$CHANGELOG" ]; then
-            # Insert the new section just before the first existing "## [" heading.
-            awk 'BEGIN{ins=0}
-                 /^## \[/ && ins==0 {while((getline line < "/tmp/new_entry.md")>0) print line; ins=1}
-                 {print}
-                 END{if(ins==0){while((getline line < "/tmp/new_entry.md")>0) print line}}' \
-                "$CHANGELOG" > /tmp/changelog.md && mv /tmp/changelog.md "$CHANGELOG"
-          else
-            cp /tmp/new_entry.md "$CHANGELOG"
-          fi
-
-          echo "Updated $CHANGELOG"
-
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Commit version bump
-        if: steps.version.outputs.skip != 'true'
+      - name: Prepare release and push
+        id: release
+        # actions/checkout pins this job to the triggering commit (github.sha). The job is serialized
+        # by the concurrency group, but while it waited on the ~5-min test job (or queued behind another
+        # release) main can advance, and it can advance again between computing the bump and pushing it.
+        # So compute version + notes against the CURRENT origin/main and commit + push as one unit; if
+        # the push is rejected, RECOMPUTE against the now-latest main and retry. Recomputing (rather than
+        # rebasing a pre-built commit) keeps the release correct whatever landed in the window:
+        #   - a non-bump commit that slipped in is folded into this release's notes and bump type;
+        #   - a competing release bump makes the range empty -> bump=none -> this run skips cleanly,
+        #     so there is no duplicate version and no colliding (non-force) tag push.
         run: |
-          NEW_VERSION="${{ steps.version.outputs.version }}"
           PACKAGE_PATH="Packages/com.orkunmanap.runtime-transform-handles"
+          MANIFEST="$PACKAGE_PATH/package.json"
+          CHANGELOG="$PACKAGE_PATH/CHANGELOG.md"
 
-          git add "$PACKAGE_PATH/package.json" "$PACKAGE_PATH/CHANGELOG.md"
-          git commit -m "chore: bump version to $NEW_VERSION [skip ci]" || echo "No changes to commit"
+          # Recompute everything from the latest origin/main, edit the files, and commit the bump.
+          # Sets NEW_VERSION / BUMP / SKIP and (re)writes /tmp/release_entries.md for later steps.
+          prepare() {
+            git fetch origin main
+            git checkout -B main origin/main
 
-          # We synced to origin/main at job start, but main can still advance during this run (the
-          # window between that sync and this push), making a plain push fail non-fast-forward.
-          # Rebase the bump onto the latest main and retry. A rebase that CONFLICTS means a competing
-          # release bump landed inside that window (both edit the same version line / CHANGELOG
-          # anchor); abort cleanly and stop rather than leaving a half-finished rebase for later steps.
+            CURRENT=$(jq -r '.version' "$MANIFEST")
+            echo "Current version: $CURRENT"
+
+            # Release boundary = the last automated version-bump commit on main (tag-independent: tags
+            # live on the orphan `upm` branch, unreachable from main, so `git describe` is wrong here).
+            RANGE_START=$(git log --grep='^chore: bump version to' --format=%H -n 1 HEAD || true)
+            if [ -n "$RANGE_START" ]; then
+              RANGE="$RANGE_START..HEAD"
+              echo "Previous release commit: $RANGE_START"
+            else
+              RANGE="HEAD"
+              echo "No previous bump commit found; treating all history as the first release."
+            fi
+            echo "Commit range: $RANGE"
+
+            # Full messages (%B) so `BREAKING CHANGE:` footers are seen, not just subjects.
+            COMMITS=$(git log $RANGE --format=%B)
+            # tformat = trailing newline after every entry so the "Generate changelog" heredoc EOF
+            # lands on its own line (plain `format:` omits the final newline and breaks it).
+            git log $RANGE --pretty=tformat:"- %s" > /tmp/release_entries.md
+
+            # Strict Conventional Commits only — no bare aliases, no "any change -> patch" fallback.
+            BUMP="none"
+            if echo "$COMMITS" | grep -qE "^BREAKING CHANGE:" \
+               || echo "$COMMITS" | grep -qiE "^[a-z]+(\(.+\))?!:"; then
+              BUMP="major"
+            elif echo "$COMMITS" | grep -qiE "^feat(\(.+\))?:"; then
+              BUMP="minor"
+            elif echo "$COMMITS" | grep -qiE "^(fix|perf|refactor)(\(.+\))?:"; then
+              BUMP="patch"
+            elif echo "$COMMITS" | grep -qiE "^(docs|style|chore|ci|test|build)(\(.+\))?:"; then
+              # Housekeeping types bump only when SHIPPING code/manifest changed (not Tests/ or Samples~/),
+              # otherwise adding a test would cut a pointless release.
+              if git log $RANGE --name-only --pretty=format: | sort -u \
+                   | grep -vE "/Tests/|/Samples~/" \
+                   | grep -qE "\.cs$|package\.json$"; then
+                BUMP="patch"
+              fi
+            fi
+            echo "Bump type: $BUMP"
+
+            if [ "$BUMP" = "none" ]; then
+              SKIP="true"
+              NEW_VERSION="$CURRENT"
+              return 0
+            fi
+            SKIP="false"
+
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            case "$BUMP" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH + 1)) ;;
+            esac
+            NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+            echo "New version: $NEW_VERSION"
+
+            jq ".version = \"$NEW_VERSION\"" "$MANIFEST" > tmp.json && mv tmp.json "$MANIFEST"
+
+            ENTRIES=$(cat /tmp/release_entries.md)
+            DATE=$(date +%Y-%m-%d)
+            {
+              echo "## [$NEW_VERSION] - $DATE"
+              echo ""
+              echo "$ENTRIES"
+              echo ""
+            } > /tmp/new_entry.md
+            if [ -f "$CHANGELOG" ]; then
+              # Insert the new section just before the first existing "## [" heading.
+              awk 'BEGIN{ins=0}
+                   /^## \[/ && ins==0 {while((getline line < "/tmp/new_entry.md")>0) print line; ins=1}
+                   {print}
+                   END{if(ins==0){while((getline line < "/tmp/new_entry.md")>0) print line}}' \
+                  "$CHANGELOG" > /tmp/changelog.md && mv /tmp/changelog.md "$CHANGELOG"
+            else
+              cp /tmp/new_entry.md "$CHANGELOG"
+            fi
+
+            git add "$MANIFEST" "$CHANGELOG"
+            git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+          }
+
+          # Each iteration recomputes against the latest main, so the loop self-corrects when main moves:
+          # the next attempt's range/version/notes reflect whatever just landed. No rebase of a stale
+          # commit, so nothing gets orphaned and a competing bump is detected as nothing-to-do.
           pushed=0
           for attempt in 1 2 3 4 5; do
-            if git push origin main; then pushed=1; break; fi
-            # The final attempt is a push only: a rebase here would have no following push to use it,
-            # so stop instead of leaving a rebased-but-unpushed bump and failing one push short.
-            if [ "$attempt" -eq 5 ]; then break; fi
-            echo "push rejected (attempt $attempt); rebasing onto origin/main"
-            if ! git pull --rebase origin main; then
-              git rebase --abort 2>/dev/null || true
-              echo "::error::version-bump rebase conflicted with main (a competing release bump already landed)."
+            prepare
+            if [ "$SKIP" = "true" ]; then
+              echo "Nothing to release (no bump in range); skipping."
               break
             fi
-            sleep $((attempt * 3))
+            if git push origin main; then pushed=1; break; fi
+            echo "push rejected (attempt $attempt); main advanced — recomputing against latest origin/main"
+            if [ "$attempt" -lt 5 ]; then sleep $((attempt * 3)); fi
           done
+
+          if [ "$SKIP" = "true" ]; then
+            {
+              echo "skip=true"
+              echo "version=$NEW_VERSION"
+              echo "bump=none"
+            } >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           if [ "$pushed" -ne 1 ]; then
             echo "::error::Failed to push the version bump after $attempt attempt(s)."
             exit 1
           fi
 
+          {
+            echo "skip=false"
+            echo "version=$NEW_VERSION"
+            echo "bump=$BUMP"
+          } >> $GITHUB_OUTPUT
+
       - name: Create/Update UPM branch
-        if: steps.version.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true'
         run: |
           PACKAGE_PATH="Packages/com.orkunmanap.runtime-transform-handles"
           UPM_BRANCH="upm"
@@ -355,15 +308,15 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Release v${{ steps.version.outputs.version }}"
+            git commit -m "Release v${{ steps.release.outputs.version }}"
             git push origin $UPM_BRANCH --force
             echo "UPM branch updated successfully!"
           fi
 
       - name: Create version tag
-        if: steps.version.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true'
         run: |
-          VERSION="v${{ steps.version.outputs.version }}"
+          VERSION="v${{ steps.release.outputs.version }}"
 
           git checkout upm
 
@@ -373,7 +326,7 @@ jobs:
           echo "Tagged version: $VERSION"
 
       - name: Generate changelog
-        if: steps.version.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true'
         id: changelog
         run: |
           # Reuse the entries computed on main. The earlier `git describe HEAD^` ran here while
@@ -383,11 +336,11 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: steps.version.outputs.skip != 'true'
+        if: steps.release.outputs.skip != 'true'
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: v${{ steps.version.outputs.version }}
+          tag_name: v${{ steps.release.outputs.version }}
+          name: v${{ steps.release.outputs.version }}
           body: |
             ## Changes
             ${{ steps.changelog.outputs.changelog }}
@@ -396,7 +349,7 @@ jobs:
 
             Add to your `manifest.json`:
             ```json
-            "com.orkunmanap.runtime-transform-handles": "https://github.com/${{ github.repository }}.git#v${{ steps.version.outputs.version }}"
+            "com.orkunmanap.runtime-transform-handles": "https://github.com/${{ github.repository }}.git#v${{ steps.release.outputs.version }}"
             ```
 
             Or use the latest:
@@ -408,14 +361,14 @@ jobs:
 
       - name: Summary
         run: |
-          if [ "${{ steps.version.outputs.skip }}" = "true" ]; then
+          if [ "${{ steps.release.outputs.skip }}" = "true" ]; then
             echo "## No Release Needed" >> $GITHUB_STEP_SUMMARY
             echo "No version bump was triggered by the commits." >> $GITHUB_STEP_SUMMARY
           else
             echo "## UPM Package Released 🎉" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Version:** v${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-            echo "**Bump Type:** ${{ steps.bump.outputs.bump }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Version:** v${{ steps.release.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Bump Type:** ${{ steps.release.outputs.bump }}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Installation" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -154,12 +154,28 @@ jobs:
           MANIFEST="$PACKAGE_PATH/package.json"
           CHANGELOG="$PACKAGE_PATH/CHANGELOG.md"
 
+          # Robust "is this version already released?" check. Distinguishes a real 404 (no release) from
+          # a transient auth/rate-limit/network error: only a 404 means "not released", anything else
+          # fails the job loudly so a flaky API call can never trigger a false recovery.
+          release_exists() {
+            local tag="$1" err
+            if err=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$tag" 2>&1 >/dev/null); then
+              return 0
+            fi
+            if printf '%s' "$err" | grep -qE "HTTP 404|Not Found"; then
+              return 1
+            fi
+            echo "::error::release lookup for $tag failed (not a 404): $err"
+            exit 1
+          }
+
           # Recompute everything from the latest origin/main, edit the files, and commit the bump.
-          # Sets NEW_VERSION / BUMP / SKIP and (re)writes /tmp/release_entries.md for later steps.
+          # Sets NEW_VERSION / BUMP / SKIP / RECOVER and (re)writes /tmp/release_entries.md for later steps.
           prepare() {
             git fetch origin main
             git checkout -B main origin/main
 
+            RECOVER="false"
             CURRENT=$(jq -r '.version' "$MANIFEST")
             echo "Current version: $CURRENT"
 
@@ -174,6 +190,25 @@ jobs:
               echo "No previous bump commit found; treating all history as the first release."
             fi
             echo "Commit range: $RANGE"
+
+            # Recovery takes priority over a new bump: if the last automated bump's version was never
+            # released (an earlier publish run pushed the bump commit, then died before tag/release),
+            # finish THAT release first — even if newer commits have since landed. Publish runs are
+            # serialized, so an unreleased bump means its run already terminated; there is no concurrent
+            # release to collide with. The newer commits keep their place in the range and ship next run.
+            if [ -n "$RANGE_START" ] && ! release_exists "v$CURRENT"; then
+              echo "v$CURRENT was bumped on main but has no release; completing it before any new bump."
+              SKIP="false"
+              RECOVER="true"
+              NEW_VERSION="$CURRENT"
+              # Recover this version's notes from its committed CHANGELOG section.
+              awk -v h="## [$CURRENT]" '
+                index($0, h) == 1 { grab = 1; next }
+                grab && /^## \[/ { exit }
+                grab && /^- /    { print }
+              ' "$CHANGELOG" > /tmp/release_entries.md
+              return 0
+            fi
 
             # Full messages (%B) so `BREAKING CHANGE:` footers are seen, not just subjects.
             COMMITS=$(git log $RANGE --format=%B)
@@ -201,28 +236,11 @@ jobs:
             fi
             echo "Bump type: $BUMP"
 
-            RECOVER="false"
+            # No new release-worthy commits and the current version is already released (recovery above
+            # handled the not-yet-released case): nothing to do.
             if [ "$BUMP" = "none" ]; then
+              SKIP="true"
               NEW_VERSION="$CURRENT"
-              # bump=none normally means "already released, nothing to do". But if an earlier run pushed
-              # this version's bump commit and then died before tagging/releasing it, main sits at a
-              # version with no GitHub release and no future run would ever finish it (the bump commit
-              # makes the range empty forever). Detect that — a bump commit exists for CURRENT but its
-              # release does not — and complete the publish instead of skipping it. No new commit to push.
-              if [ -n "$RANGE_START" ] \
-                 && ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v$CURRENT" >/dev/null 2>&1; then
-                echo "v$CURRENT was bumped on main but has no release; completing the publish."
-                SKIP="false"
-                RECOVER="true"
-                # Recover this version's notes from its committed CHANGELOG section.
-                awk -v h="## [$CURRENT]" '
-                  index($0, h) == 1 { grab = 1; next }
-                  grab && /^## \[/ { exit }
-                  grab && /^- /    { print }
-                ' "$CHANGELOG" > /tmp/release_entries.md
-              else
-                SKIP="true"
-              fi
               return 0
             fi
             SKIP="false"

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -306,13 +306,16 @@ jobs:
           pushed=0
           for attempt in 1 2 3 4 5; do
             if git push origin main; then pushed=1; break; fi
+            # The final attempt is a push only: a rebase here would have no following push to use it,
+            # so stop instead of leaving a rebased-but-unpushed bump and failing one push short.
+            if [ "$attempt" -eq 5 ]; then break; fi
             echo "push rejected (attempt $attempt); rebasing onto origin/main"
             if ! git pull --rebase origin main; then
               git rebase --abort 2>/dev/null || true
               echo "::error::version-bump rebase conflicted with main (a competing release bump already landed)."
               break
             fi
-            if [ "$attempt" -lt 5 ]; then sleep $((attempt * 3)); fi
+            sleep $((attempt * 3))
           done
           if [ "$pushed" -ne 1 ]; then
             echo "::error::Failed to push the version bump after $attempt attempt(s)."

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -286,17 +286,23 @@ jobs:
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]" || echo "No changes to commit"
 
           # main can advance between this run's checkout and now (e.g. another PR merged while this
-          # run was queued behind the concurrency gate), which makes a plain push fail with
-          # non-fast-forward. Rebase the bump onto the latest main and retry so the release lands.
+          # run was queued behind the concurrency gate), making a plain push fail non-fast-forward.
+          # Rebase the bump onto the latest main and retry. A rebase that CONFLICTS means a competing
+          # release bump already landed (both edit the same version line / CHANGELOG anchor); abort
+          # cleanly and stop rather than leaving a half-finished rebase for later steps to copy.
           pushed=0
           for attempt in 1 2 3 4 5; do
             if git push origin main; then pushed=1; break; fi
-            echo "push rejected (attempt $attempt); rebasing onto origin/main and retrying"
-            git pull --rebase origin main || true
-            sleep $((attempt * 3))
+            echo "push rejected (attempt $attempt); rebasing onto origin/main"
+            if ! git pull --rebase origin main; then
+              git rebase --abort 2>/dev/null || true
+              echo "::error::version-bump rebase conflicted with main (a competing release bump already landed)."
+              break
+            fi
+            if [ "$attempt" -lt 5 ]; then sleep $((attempt * 3)); fi
           done
           if [ "$pushed" -ne 1 ]; then
-            echo "::error::Failed to push the version bump after 5 attempts."
+            echo "::error::Failed to push the version bump after $attempt attempt(s)."
             exit 1
           fi
 

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -131,6 +131,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Sync to latest main
+        # The publish job is serialized by the concurrency group, but actions/checkout pins to the
+        # triggering commit (github.sha). While this run waited on the ~5-min test job (or queued
+        # behind another release), main may have advanced. Compute the version against the REAL
+        # latest main so that a release another run already landed is seen as "nothing to bump" and
+        # this run skips cleanly, instead of recomputing a stale/duplicate version that then collides
+        # on push (rebase conflict) or on the non-force tag push. The retry loop in "Commit version
+        # bump" only has to cover main advancing during this job's own (seconds-long) window.
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
+          echo "Synced to origin/main: $(git rev-parse --short HEAD)"
+
       - name: Get current version
         id: current
         run: |
@@ -285,11 +298,11 @@ jobs:
           git add "$PACKAGE_PATH/package.json" "$PACKAGE_PATH/CHANGELOG.md"
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]" || echo "No changes to commit"
 
-          # main can advance between this run's checkout and now (e.g. another PR merged while this
-          # run was queued behind the concurrency gate), making a plain push fail non-fast-forward.
+          # We synced to origin/main at job start, but main can still advance during this run (the
+          # window between that sync and this push), making a plain push fail non-fast-forward.
           # Rebase the bump onto the latest main and retry. A rebase that CONFLICTS means a competing
-          # release bump already landed (both edit the same version line / CHANGELOG anchor); abort
-          # cleanly and stop rather than leaving a half-finished rebase for later steps to copy.
+          # release bump landed inside that window (both edit the same version line / CHANGELOG
+          # anchor); abort cleanly and stop rather than leaving a half-finished rebase for later steps.
           pushed=0
           for attempt in 1 2 3 4 5; do
             if git push origin main; then pushed=1; break; fi

--- a/.github/workflows/publish-upm.yml
+++ b/.github/workflows/publish-upm.yml
@@ -200,7 +200,11 @@ jobs:
               echo "v$CURRENT was bumped on main but has no release; completing it before any new bump."
               SKIP="false"
               RECOVER="true"
+              BUMP="none"
               NEW_VERSION="$CURRENT"
+              # Package the bump commit's tree, NOT HEAD — commits that landed after the interrupted
+              # publish must not ship under this recovered tag (they release on a later run).
+              RELEASE_REF="$RANGE_START"
               # Recover this version's notes from its committed CHANGELOG section.
               awk -v h="## [$CURRENT]" '
                 index($0, h) == 1 { grab = 1; next }
@@ -277,6 +281,8 @@ jobs:
 
             git add "$MANIFEST" "$CHANGELOG"
             git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+            # Package exactly this bump commit, so later steps are immune to main advancing again.
+            RELEASE_REF="$(git rev-parse HEAD)"
           }
 
           # Each iteration recomputes against the latest main, so the loop self-corrects when main moves:
@@ -317,6 +323,7 @@ jobs:
             echo "skip=false"
             echo "version=$NEW_VERSION"
             echo "bump=$BUMP"
+            echo "release_ref=$RELEASE_REF"
           } >> $GITHUB_OUTPUT
 
       - name: Create/Update UPM branch
@@ -324,6 +331,9 @@ jobs:
         run: |
           PACKAGE_PATH="Packages/com.orkunmanap.runtime-transform-handles"
           UPM_BRANCH="upm"
+          # Exact commit whose package this release ships: the bump commit (normal) or the
+          # interrupted bump being recovered. Never plain `main`, which may have moved on.
+          RELEASE_REF="${{ steps.release.outputs.release_ref }}"
 
           if git ls-remote --heads origin $UPM_BRANCH | grep -q $UPM_BRANCH; then
             echo "UPM branch exists, updating..."
@@ -332,7 +342,7 @@ jobs:
 
             find . -maxdepth 1 ! -name '.git' ! -name '.' -exec rm -rf {} +
 
-            git checkout main -- "$PACKAGE_PATH"
+            git checkout "$RELEASE_REF" -- "$PACKAGE_PATH"
             mv "$PACKAGE_PATH"/* .
             rm -rf Packages
           else
@@ -342,7 +352,7 @@ jobs:
             git rm -rf . || true
             git clean -fd
 
-            git checkout main -- "$PACKAGE_PATH"
+            git checkout "$RELEASE_REF" -- "$PACKAGE_PATH"
             mv "$PACKAGE_PATH"/* .
             rm -rf Packages
           fi

--- a/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Align axis and uniform scale input with Unity Editor handle math (`CalcLineTranslation`, `GetHandleSize`).
+- Keep scale axis line and cube gizmo visuals in sync (tube mesh length vs cube rest distance).
+- Reset scale axis gizmo visuals on drag end and re-initialize; guard absolute snap when start scale is zero.
+- Guard scale handles when the interaction camera is missing.
+
+### Added
+- `HandleTransformUtility` runtime port of Unity Editor scale handle math.
+- Edit Mode tests for handle transform utility and line/cube visual reach parity.
+
 ## [3.0.3] - 2026-06-01
 
 - Merge pull request #34 from manaporkun/test/group-apply-paths

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleAxis.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleAxis.cs
@@ -18,10 +18,11 @@ namespace TransformHandles
 
         private Vector3 _axis;
         private Vector3 _startScale;
+        private Vector2 _startMousePosition;
 
-        private float _interactionDistance;
+        private float _cubeRestDistance;
+        private float _lineMeshLength;
         private float _lastDelta = float.NaN;
-        private Ray _rAxisRay;
 
         private Material _cubeMaterial;
         private Material _lineMaterial;
@@ -43,6 +44,31 @@ namespace TransformHandles
             // and MeshRenderer.material allocates a new instance on every access.
             if (_cubeMaterial == null) _cubeMaterial = cubeMeshRenderer.material;
             if (_lineMaterial == null) _lineMaterial = lineMeshRenderer.material;
+
+            delta = 0f;
+            _lastDelta = float.NaN;
+            CacheVisualRestLengths();
+            ApplyVisualDelta(1f);
+        }
+
+        private void CacheVisualRestLengths()
+        {
+            _cubeRestDistance = Mathf.Abs(Vector3.Dot(cubeMeshRenderer.transform.localPosition, _axis));
+            if (_cubeRestDistance <= 0f)
+                _cubeRestDistance = ScaleCubeSize;
+
+            var meshFilter = lineMeshRenderer.GetComponent<MeshFilter>();
+            var mesh = meshFilter != null ? meshFilter.sharedMesh : null;
+            _lineMeshLength = mesh != null ? mesh.bounds.size.y : 0f;
+            if (_lineMeshLength <= 0f)
+                _lineMeshLength = ScaleCubeSize;
+        }
+
+        private void ApplyVisualDelta(float scaleFactor)
+        {
+            var lineScaleY = _cubeRestDistance / _lineMeshLength * scaleFactor;
+            lineMeshRenderer.transform.localScale = new Vector3(1f, lineScaleY, 1f);
+            cubeMeshRenderer.transform.localPosition = _axis * (_cubeRestDistance * scaleFactor);
         }
 
         protected void Update()
@@ -51,38 +77,46 @@ namespace TransformHandles
             if (delta == _lastDelta) return;
             _lastDelta = delta;
 
-            lineMeshRenderer.transform.localScale = new Vector3(1, 1 + delta, 1);
-            cubeMeshRenderer.transform.localPosition = _axis * (ScaleCubeSize * (1 + delta));
+            ApplyVisualDelta(1f + delta);
         }
 
         /// <inheritdoc/>
         public override void Interact(Vector3 previousPosition)
         {
-            var cameraRay = _handleCamera.ScreenPointToRay(InputWrapper.MousePosition);
+            if (_handleCamera == null) return;
 
-            var closestT = MathUtils.ClosestPointOnRay(_rAxisRay, cameraRay);
-            var hitPoint = _rAxisRay.GetPoint(closestT);
+            var position = ParentHandle.target.position;
+            var direction = GetRotatedAxis(_axis);
+            var handleSize = HandleTransformUtility.GetHandleSize(position, _handleCamera);
+            var lineTranslation = HandleTransformUtility.CalcLineTranslation(
+                _startMousePosition,
+                InputWrapper.MousePosition,
+                position,
+                direction,
+                _handleCamera);
 
-            var distance = Vector3.Distance(ParentHandle.target.position, hitPoint);
-            var axisScaleDelta = distance / _interactionDistance - 1f;
+            // Unity SliderScale.DoAxis: dist = 1 + CalcLineTranslation(...) / handleSize; scale = start * dist.
+            var dist = 1f + lineTranslation / handleSize;
 
-            var snapping = ParentHandle.scaleSnap;
-            var snap = Mathf.Abs(Vector3.Dot(snapping, _axis));
+            var snap = Mathf.Abs(Vector3.Dot(ParentHandle.scaleSnap, _axis));
             if (snap != 0)
             {
                 if (ParentHandle.snappingType == SnappingType.Relative)
                 {
-                    axisScaleDelta = SnapUtils.Snap(axisScaleDelta, snap);
+                    dist = SnapUtils.Snap(dist, snap);
                 }
                 else
                 {
-                    var axisStartScale = Mathf.Abs(Vector3.Dot(_startScale, _axis));
-                    axisScaleDelta = SnapUtils.Snap(axisScaleDelta + axisStartScale, snap) - axisStartScale;
+                    var axisStartScale = GetAxisStartScale();
+                    if (axisStartScale > 0f)
+                        dist = SnapUtils.Snap(axisStartScale * dist, snap) / axisStartScale;
+                    else
+                        dist = SnapUtils.Snap(dist, snap);
                 }
             }
 
-            delta = axisScaleDelta;
-            var scale = Vector3.Scale(_startScale, _axis * axisScaleDelta + Vector3.one);
+            delta = dist - 1f;
+            var scale = Vector3.Scale(_startScale, _axis * delta + Vector3.one);
 
             ParentHandle.target.localScale = scale;
 
@@ -94,18 +128,15 @@ namespace TransformHandles
         {
             base.StartInteraction(hitPoint);
             _startScale = ParentHandle.target.localScale;
+            _startMousePosition = InputWrapper.MousePosition;
+        }
 
-            var rAxis = GetRotatedAxis(_axis);
-
-            var position = ParentHandle.target.position;
-            _rAxisRay = new Ray(position, rAxis);
-
-            var cameraRay = _handleCamera.ScreenPointToRay(InputWrapper.MousePosition);
-
-            var closestT = MathUtils.ClosestPointOnRay(_rAxisRay, cameraRay);
-            var rayHitPoint = _rAxisRay.GetPoint(closestT);
-
-            _interactionDistance = Vector3.Distance(position, rayHitPoint);
+        /// <inheritdoc/>
+        public override void EndInteraction()
+        {
+            base.EndInteraction();
+            _lastDelta = float.NaN;
+            ApplyVisualDelta(1f);
         }
 
         /// <inheritdoc/>
@@ -120,6 +151,13 @@ namespace TransformHandles
         {
             if (_cubeMaterial.color != DefaultColor) _cubeMaterial.color = DefaultColor;
             if (_lineMaterial.color != DefaultColor) _lineMaterial.color = DefaultColor;
+        }
+
+        private float GetAxisStartScale()
+        {
+            if (Mathf.Abs(_axis.x) > 0.5f) return Mathf.Abs(_startScale.x);
+            if (Mathf.Abs(_axis.y) > 0.5f) return Mathf.Abs(_startScale.y);
+            return Mathf.Abs(_startScale.z);
         }
     }
 }

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleGlobal.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/HandleComponents/Scale/ScaleGlobal.cs
@@ -8,15 +8,13 @@ namespace TransformHandles
     /// </summary>
     public class ScaleGlobal : HandleBase
     {
-        // Scale delta per pixel dragged. Chosen to match the previous feel at 60 fps
-        // (the old code used 2f * Time.deltaTime, i.e. ~2/60 per pixel at 60 fps).
-        private const float MouseSensitivity = 0.0333f;
-
         [SerializeField] private Color defaultColor;
         [SerializeField] private MeshRenderer cubeMeshRenderer;
 
         private Vector3 _axis;
         private Vector3 _startScale;
+        private Vector2 _startMousePosition;
+        private Vector3 _uniformScaleDirection;
         private Material _cubeMaterial;
 
         /// <summary>
@@ -38,12 +36,30 @@ namespace TransformHandles
         /// <inheritdoc/>
         public override void Interact(Vector3 previousPosition)
         {
-            var mouseVector = (Vector3)InputWrapper.MousePosition - previousPosition;
-            // mouseVector is the per-frame pixel delta; the total scale change should depend on how
-            // far the mouse moved, not on the frame rate. Multiplying by Time.deltaTime made scaling
-            // speed framerate-dependent (higher fps -> smaller dt -> slower scaling). Drop it.
-            var d = (mouseVector.x + mouseVector.y) * MouseSensitivity;
-            delta += d;
+            var camera = ParentHandle.handleCamera;
+            if (camera == null) return;
+
+            var position = ParentHandle.target.position;
+            var handleSize = HandleTransformUtility.GetHandleSize(position, camera);
+            var lineTranslation = HandleTransformUtility.CalcLineTranslation(
+                _startMousePosition,
+                InputWrapper.MousePosition,
+                position,
+                _uniformScaleDirection,
+                camera);
+
+            // Unity SliderScale.DoCenter: value = (Snap(CalcLineTranslation(...) / size) + 1) * startScale.
+            var dist = lineTranslation / handleSize;
+            var snap = GetActiveScaleSnap();
+            if (snap != 0)
+            {
+                if (ParentHandle.snappingType == SnappingType.Relative)
+                    dist = SnapUtils.Snap(dist, snap);
+                else
+                    dist = SnapUtils.Snap(dist + 1f, snap) - 1f;
+            }
+
+            delta = dist;
             ParentHandle.target.localScale = _startScale + Vector3.Scale(_startScale, _axis) * delta;
 
             base.Interact(previousPosition);
@@ -54,6 +70,17 @@ namespace TransformHandles
         {
             base.StartInteraction(hitPoint);
             _startScale = ParentHandle.target.localScale;
+            _startMousePosition = InputWrapper.MousePosition;
+
+            var camera = ParentHandle.handleCamera;
+            if (camera == null)
+            {
+                _uniformScaleDirection = Vector3.one;
+                return;
+            }
+
+            var cameraTransform = camera.transform;
+            _uniformScaleDirection = (cameraTransform.right + cameraTransform.up).normalized;
         }
 
         /// <inheritdoc/>
@@ -66,6 +93,16 @@ namespace TransformHandles
         public override void SetDefaultColor()
         {
             if (_cubeMaterial.color != DefaultColor) _cubeMaterial.color = DefaultColor;
+        }
+
+        private float GetActiveScaleSnap()
+        {
+            var snap = ParentHandle.scaleSnap;
+            var max = 0f;
+            if (_axis.x > 0f) max = Mathf.Max(max, snap.x);
+            if (_axis.y > 0f) max = Mathf.Max(max, snap.y);
+            if (_axis.z > 0f) max = Mathf.Max(max, snap.z);
+            return max;
         }
     }
 }

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/Utils/HandleTransformUtility.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/Utils/HandleTransformUtility.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+
+namespace TransformHandles.Utils
+{
+    /// <summary>
+    /// Runtime equivalents of Unity Editor handle math used by the built-in scale tool
+    /// (HandleUtility.CalcLineTranslation and HandleUtility.GetHandleSize).
+    /// </summary>
+    public static class HandleTransformUtility
+    {
+        /// <summary>Matches Unity Editor <c>HandleUtility.k_KHandleSize</c>.</summary>
+        public const float DefaultHandleSizeConstant = 80f;
+
+        /// <summary>
+        /// Returns the world-space handle size at <paramref name="position"/> for the given camera.
+        /// Mirrors Unity Editor <c>HandleUtility.GetHandleSize</c>.
+        /// </summary>
+        public static float GetHandleSize(Vector3 position, Camera camera, float handleSizeConstant = DefaultHandleSizeConstant)
+        {
+            if (camera == null) return 20f;
+
+            var tr = camera.transform;
+            var camPos = tr.position;
+            var distance = Vector3.Dot(position - camPos, tr.TransformDirection(Vector3.forward));
+            var screenPos = camera.WorldToScreenPoint(camPos + tr.TransformDirection(new Vector3(0f, 0f, distance)));
+            var screenPos2 = camera.WorldToScreenPoint(camPos + tr.TransformDirection(new Vector3(1f, 0f, distance)));
+            var screenDist = (screenPos - screenPos2).magnitude;
+            return handleSizeConstant / Mathf.Max(screenDist, 0.0001f);
+        }
+
+        /// <summary>
+        /// Maps a screen-space drag onto movement along a 3D line. Screen coordinates must use a
+        /// bottom-left origin (Unity <c>Input.mousePosition</c> / <c>Camera.WorldToScreenPoint</c>).
+        /// Mirrors Unity Editor <c>HandleUtility.CalcLineTranslation</c>.
+        /// </summary>
+        public static float CalcLineTranslation(Vector2 src, Vector2 dest, Vector3 srcPosition, Vector3 constraintDir, Camera camera)
+        {
+            var invert = 1f;
+            var cameraForward = camera != null ? camera.transform.forward : Vector3.forward;
+            if (Vector3.Dot(constraintDir, cameraForward) < 0f)
+                invert = -1f;
+
+            Vector2 p1;
+            Vector2 p2;
+            if (camera == null)
+            {
+                p1 = Vector2.Scale(srcPosition, new Vector2(1f, -1f));
+                p2 = Vector2.Scale(srcPosition + constraintDir * invert, new Vector2(1f, -1f));
+            }
+            else
+            {
+                p1 = camera.WorldToScreenPoint(srcPosition);
+                p2 = camera.WorldToScreenPoint(srcPosition + constraintDir * invert);
+            }
+
+            var p3 = dest;
+            var p4 = src;
+
+            if (p1 == p2)
+                return 0f;
+
+            var t0 = GetParametrization(p4, p1, p2);
+            var t1 = GetParametrization(p3, p1, p2);
+            return (t1 - t0) * invert;
+        }
+
+        internal static float GetParametrization(Vector2 x0, Vector2 x1, Vector2 x2)
+        {
+            return -(Vector2.Dot(x1 - x0, x2 - x1) / (x2 - x1).sqrMagnitude);
+        }
+    }
+}

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/Utils/HandleTransformUtility.cs.meta
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/Utils/HandleTransformUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f9a8265b55ed34f129f27c76c5ca5b37

--- a/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/HandleTransformUtilityTests.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/HandleTransformUtilityTests.cs
@@ -1,0 +1,81 @@
+using NUnit.Framework;
+using TransformHandles.Utils;
+using UnityEngine;
+
+namespace TransformHandles.Tests.Editor
+{
+    public class HandleTransformUtilityTests
+    {
+        [Test]
+        public void GetParametrization_returns_zero_when_point_is_at_line_start()
+        {
+            var p1 = Vector2.zero;
+            var p2 = Vector2.right;
+            var x0 = p1;
+
+            var t = HandleTransformUtility.GetParametrization(x0, p1, p2);
+
+            Assert.AreEqual(0f, t, 1e-4f);
+        }
+
+        [Test]
+        public void GetParametrization_returns_one_when_point_is_at_line_end()
+        {
+            var p1 = Vector2.zero;
+            var p2 = Vector2.right;
+            var x0 = p2;
+
+            var t = HandleTransformUtility.GetParametrization(x0, p1, p2);
+
+            Assert.AreEqual(1f, t, 1e-4f);
+        }
+
+        [Test]
+        public void CalcLineTranslation_returns_zero_when_src_equals_dest()
+        {
+            var cameraGo = new GameObject("Camera");
+            var camera = cameraGo.AddComponent<Camera>();
+            camera.transform.position = new Vector3(0f, 0f, -10f);
+            camera.transform.rotation = Quaternion.identity;
+            camera.orthographic = false;
+
+            try
+            {
+                var src = new Vector2(100f, 100f);
+                var translation = HandleTransformUtility.CalcLineTranslation(
+                    src,
+                    src,
+                    Vector3.zero,
+                    Vector3.right,
+                    camera);
+
+                Assert.AreEqual(0f, translation, 1e-3f);
+            }
+            finally
+            {
+                Object.DestroyImmediate(cameraGo);
+            }
+        }
+
+        [Test]
+        public void GetHandleSize_returns_fallback_when_camera_is_null()
+        {
+            Assert.AreEqual(20f, HandleTransformUtility.GetHandleSize(Vector3.zero, null));
+        }
+
+        [Test]
+        public void LineVisualScale_reaches_same_distance_as_cube_for_tube_mesh()
+        {
+            const float cubeRestDistance = 0.75f;
+            const float lineMeshLength = 0.8f;
+
+            foreach (var scaleFactor in new[] { 0.5f, 1f, 1.5f, 2f })
+            {
+                var lineScaleY = cubeRestDistance / lineMeshLength * scaleFactor;
+                var lineReach = lineMeshLength * lineScaleY;
+                var cubeReach = cubeRestDistance * scaleFactor;
+                Assert.AreEqual(cubeReach, lineReach, 1e-5f);
+            }
+        }
+    }
+}

--- a/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/HandleTransformUtilityTests.cs.meta
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Tests/Editor/HandleTransformUtilityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09aa3f16f40264a83ba3eca84ed54675


### PR DESCRIPTION
Follow-up hardening after the 3.0.3 release race. Two layers, addressing the same root cause — a publish run computing/pushing a version against a base that `main` has moved past.

## Root cause
`actions/checkout` pins the `publish` job to the triggering commit (`github.sha`). The job is serialized by the concurrency group, but while it waits on the ~5-min `test` job (or queues behind another release), `main` can advance. The version was then computed against a stale base, and a queued run could recompute a version another run had already shipped.

## 1. Compute the version against fresh `origin/main`
New `Sync to latest main` step (`git fetch origin main && git checkout -B main origin/main`) runs before version determination. A release that already landed is now seen as nothing-to-bump, so the run **skips cleanly** instead of recomputing a stale/duplicate version that collides on push or on the non-force tag push. Release notes / CHANGELOG also reflect real latest main.

## 2. Fail-clean push retry (backstop)
`main` can still advance during this job's own (seconds-long) window between sync and push. The `Commit version bump` push retries with rebase on non-fast-forward. A rebase that **conflicts** means a competing bump landed in that window (both edit the same version line / CHANGELOG anchor) — it aborts the rebase and fails fast with a clear error, rather than swallowing the failure via `|| true` and leaving a half-finished rebase for later steps.

`ci:` only -> no release on merge. YAML validated; `validate` + `test` green.

Closes #37.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Publish workflow changes affect versioning, tagging, and release recovery on every main push; scale interaction changes alter end-user transform behavior in runtime.
> 
> **Overview**
> **Hardens the UPM publish job** so version bumps, changelog notes, and pushes are computed from fresh `origin/main` in a single **Prepare release and push** step, with up to five **recompute-and-retry** cycles when `main` moves instead of rebasing a stale bump. Adds **recovery** when a version was bumped on `main` but never got a GitHub release (via `gh api` 404-only checks), ships the **`upm` branch from a pinned `release_ref`** (not floating `main`), and makes **tag creation idempotent** for recovery runs. Downstream steps now read `steps.release` outputs.
> 
> **Aligns runtime scale handles with Unity Editor math** by adding **`HandleTransformUtility`** (`GetHandleSize`, `CalcLineTranslation`) and rewiring **`ScaleAxis`** and **`ScaleGlobal`** to use screen-drag translation instead of ray-distance or per-pixel delta scaling. **`ScaleAxis`** keeps line and cube gizmo reach in sync, resets visuals on drag end/re-init, and guards missing cameras and zero absolute snap. **`CHANGELOG.md`** gains an **[Unreleased]** section; **Edit Mode tests** cover the utility and line/cube visual parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501b1eeac43b9cd0721d357af68206c2e591bd77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->