### PR TITLE
docs: add Samples section with import steps to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ If no settings asset is assigned, the manager uses its serialized field values.
 | X | Toggle World/Local space |
 | Z | Toggle Pivot/Center origin |
 
+## Samples
+
+The package ships an importable demo:
+
+1. Open `Window > Package Manager` and select **Runtime Transform Handles**.
+2. Open the **Samples** tab and import **Runtime Transform Handles Demo**.
+3. Open `Assets/Samples/Runtime Transform Handles/<version>/Runtime Transform Handles Demo/RuntimeTransformHandlesDemo.unity` and enter Play mode.
+
+The demo spawns its own targets and exercises every handle type, axis mask, coordinate space,
+snapping mode, multi-object grouping, auto-scaling, and the interaction event system through an
+on-screen control panel (see the sample's own README for the controls table). The imported copy
+under `Assets/Samples/` is regenerable — it can be deleted and reimported at any time.
+
 ## Package Structure
 
 ```


### PR DESCRIPTION
The package README documents the sample, but the root README only mentioned it in the package-structure tree. Adds a dedicated **Samples** section: Package Manager import steps, what the demo exercises, and a note that the imported copy under `Assets/Samples/` is regenerable.

Docs-only — no release will be cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the root README; no runtime or package code affected.
> 
> **Overview**
> Adds a **Samples** section to the root `README.md` (between default shortcuts and Package Structure) so users can find the UPM demo without digging the package tree alone.
> 
> It documents Package Manager import steps for **Runtime Transform Handles Demo**, the path to `RuntimeTransformHandlesDemo.unity`, what the scene covers (handle types, axes, space, snapping, multi-select, auto-scale, events), and that `Assets/Samples/` copies are safe to delete and reimport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c03d21b6a572c25098ccd350ea807d0d744e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->