### PR TITLE
feat: block handle interaction start when pointer is over uGUI

### DIFF
--- a/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an interaction already in progress is never interrupted. Requires the uGUI package and an
   `EventSystem` in the scene — projects without uGUI are unaffected (the guard is a no-op via the
   `TH_UGUI` version define). Override `IsPointerOverUI()` to integrate a non-uGUI UI stack.
+  The Demo sample now spawns a uGUI panel and an EventSystem and exposes a HUD toggle so the
+  guard can be tried directly: with it on, clicking the panel does not disturb objects behind it.
 
 ## [3.1.0] - 2026-06-11
 

--- a/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- UI-occlusion guard: handle interactions no longer start while the pointer is over a uGUI
-  element. Controlled by `TransformHandleManager.BlockWhenPointerOverUI` (serialized, default on);
-  an interaction already in progress is never interrupted. Requires the uGUI package and an
-  `EventSystem` in the scene — projects without uGUI are unaffected (the guard is a no-op via the
-  `TH_UGUI` version define). Override `IsPointerOverUI()` to integrate a non-uGUI UI stack.
+- Optional UI-occlusion guard: when enabled, handle interactions do not start while the pointer
+  is over a uGUI element. Opt-in via `TransformHandleManager.BlockWhenPointerOverUI` (serialized,
+  **off by default** so it never silently changes existing input behavior); an interaction already
+  in progress is never interrupted, and touch is handled via the active finger's pointer id.
+  Requires the uGUI package and an `EventSystem` in the scene — projects without uGUI are
+  unaffected (no-op via the `TH_UGUI` version define). Override `IsPointerOverUI()` to integrate a
+  non-uGUI UI stack.
   The Demo sample now spawns a uGUI panel and an EventSystem and exposes a HUD toggle so the
   guard can be tried directly: with it on, clicking the panel does not disturb objects behind it.
 

--- a/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- UI-occlusion guard: handle interactions no longer start while the pointer is over a uGUI
+  element. Controlled by `TransformHandleManager.BlockWhenPointerOverUI` (serialized, default on);
+  an interaction already in progress is never interrupted. Requires the uGUI package and an
+  `EventSystem` in the scene — projects without uGUI are unaffected (the guard is a no-op via the
+  `TH_UGUI` version define). Override `IsPointerOverUI()` to integrate a non-uGUI UI stack.
+
 ## [3.1.0] - 2026-06-11
 
 ### Added

--- a/Packages/com.orkunmanap.runtime-transform-handles/README.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/README.md
@@ -92,6 +92,19 @@ type/space/axes, and highlight color, then assign it:
 TransformHandleManager.Instance.Settings = mySettings;
 ```
 
+### Blocking interaction over UI
+
+By default a handle interaction will not start while the pointer is over a uGUI element, so
+clicking a button or panel rendered above the scene does not begin a drag (an interaction already
+in progress is never interrupted). This needs an `EventSystem` in the scene and the uGUI package;
+projects without uGUI are unaffected. Toggle it at runtime or in the Inspector:
+
+```csharp
+TransformHandleManager.Instance.BlockWhenPointerOverUI = false;
+```
+
+For a non-uGUI UI stack, subclass and override `IsPointerOverUI()`.
+
 ## Default keyboard shortcuts
 
 | Key | Action |

--- a/Packages/com.orkunmanap.runtime-transform-handles/README.md
+++ b/Packages/com.orkunmanap.runtime-transform-handles/README.md
@@ -92,15 +92,16 @@ type/space/axes, and highlight color, then assign it:
 TransformHandleManager.Instance.Settings = mySettings;
 ```
 
-### Blocking interaction over UI
+### Blocking interaction over UI (opt-in)
 
-By default a handle interaction will not start while the pointer is over a uGUI element, so
-clicking a button or panel rendered above the scene does not begin a drag (an interaction already
-in progress is never interrupted). This needs an `EventSystem` in the scene and the uGUI package;
-projects without uGUI are unaffected. Toggle it at runtime or in the Inspector:
+Optionally, a handle interaction can be prevented from starting while the pointer is over a uGUI
+element, so clicking a button or panel above the scene does not begin a drag (an interaction
+already in progress is never interrupted; touch uses the active finger). It is **off by default**
+so it never silently changes input behavior. Needs an `EventSystem` and the uGUI package; projects
+without uGUI are unaffected. Enable it at runtime or in the Inspector:
 
 ```csharp
-TransformHandleManager.Instance.BlockWhenPointerOverUI = false;
+TransformHandleManager.Instance.BlockWhenPointerOverUI = true;
 ```
 
 For a non-uGUI UI stack, subclass and override `IsPointerOverUI()`.

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
@@ -450,7 +450,13 @@ namespace TransformHandles
             if (!blockWhenPointerOverUI) return false;
 #if TH_UGUI
             var eventSystem = UnityEngine.EventSystems.EventSystem.current;
-            return eventSystem != null && eventSystem.IsPointerOverGameObject();
+            if (eventSystem == null) return false;
+
+            // The no-arg overload only queries the mouse pointer. The package treats the first
+            // active touch as the primary pointer (see InputWrapper), so on touch devices also
+            // test that finger's pointer id — otherwise a tap over UI bypasses the guard.
+            if (eventSystem.IsPointerOverGameObject()) return true;
+            return HasActiveTouch && eventSystem.IsPointerOverGameObject(PrimaryTouchPointerId);
 #else
             return false;
 #endif

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
@@ -41,6 +41,11 @@ namespace TransformHandles
         [SerializeField] private string handleLayerName = "TransformHandle";
         [SerializeField] private Color highlightColor = Color.white;
 
+        [Tooltip("When enabled, a handle interaction will not start while the pointer is over a " +
+                 "uGUI element (requires an EventSystem in the scene). An interaction already in " +
+                 "progress is never interrupted, even if the pointer moves over UI.")]
+        [SerializeField] private bool blockWhenPointerOverUI = true;
+
         [Header("Shortcuts (used when no Settings asset is assigned)")]
         [SerializeField] private KeyCode positionShortcut = KeyCode.W;
         [SerializeField] private KeyCode rotationShortcut = KeyCode.E;
@@ -57,6 +62,17 @@ namespace TransformHandles
         {
             get => settings;
             set => settings = value;
+        }
+
+        /// <summary>
+        /// When true, a handle interaction will not start while the pointer is over a uGUI element
+        /// (requires the uGUI package and an EventSystem in the scene). An in-progress interaction
+        /// is never interrupted. Defaults to true. Has no effect when uGUI is not installed.
+        /// </summary>
+        public bool BlockWhenPointerOverUI
+        {
+            get => blockWhenPointerOverUI;
+            set => blockWhenPointerOverUI = value;
         }
 
         // Properties that check settings first, then fall back to serialized fields
@@ -407,13 +423,37 @@ namespace TransformHandles
                 _hoveredHandle = null;
                 _handleHitPoint = Vector3.zero;
 
-                GetHandle(ref _hoveredHandle, ref _handleHitPoint);
+                // Leaving the hovered handle null while the pointer is over UI both clears the
+                // highlight and prevents MouseInput from starting a drag (it requires a hovered
+                // handle). An interaction already in progress is unaffected — this branch only
+                // runs when not dragging.
+                if (!IsPointerOverUI())
+                {
+                    GetHandle(ref _hoveredHandle, ref _handleHitPoint);
+                }
 
                 HandleOverEffect(_hoveredHandle);
             }
 
             MouseInput();
             KeyboardInput();
+        }
+
+        /// <summary>
+        /// Whether the pointer is currently over a uGUI element that should suppress starting a
+        /// handle interaction. Returns false when <see cref="BlockWhenPointerOverUI"/> is disabled,
+        /// no EventSystem is present, or the uGUI package is not installed. Override to plug in a
+        /// different UI stack.
+        /// </summary>
+        protected virtual bool IsPointerOverUI()
+        {
+            if (!blockWhenPointerOverUI) return false;
+#if TH_UGUI
+            var eventSystem = UnityEngine.EventSystems.EventSystem.current;
+            return eventSystem != null && eventSystem.IsPointerOverGameObject();
+#else
+            return false;
+#endif
         }
 
         protected virtual void GetHandle(ref HandleBase handle, ref Vector3 hitPoint)

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/TransformHandleManager.cs
@@ -41,10 +41,11 @@ namespace TransformHandles
         [SerializeField] private string handleLayerName = "TransformHandle";
         [SerializeField] private Color highlightColor = Color.white;
 
-        [Tooltip("When enabled, a handle interaction will not start while the pointer is over a " +
-                 "uGUI element (requires an EventSystem in the scene). An interaction already in " +
-                 "progress is never interrupted, even if the pointer moves over UI.")]
-        [SerializeField] private bool blockWhenPointerOverUI = true;
+        [Tooltip("Opt-in: when enabled, a handle interaction will not start while the pointer is " +
+                 "over a uGUI element (requires an EventSystem in the scene). An interaction " +
+                 "already in progress is never interrupted, even if the pointer moves over UI. " +
+                 "Off by default so it never silently changes existing input behavior.")]
+        [SerializeField] private bool blockWhenPointerOverUI;
 
         [Header("Shortcuts (used when no Settings asset is assigned)")]
         [SerializeField] private KeyCode positionShortcut = KeyCode.W;
@@ -65,9 +66,10 @@ namespace TransformHandles
         }
 
         /// <summary>
-        /// When true, a handle interaction will not start while the pointer is over a uGUI element
-        /// (requires the uGUI package and an EventSystem in the scene). An in-progress interaction
-        /// is never interrupted. Defaults to true. Has no effect when uGUI is not installed.
+        /// Opt-in. When true, a handle interaction will not start while the pointer is over a uGUI
+        /// element (requires the uGUI package and an EventSystem in the scene). An in-progress
+        /// interaction is never interrupted. Defaults to false so enabling the package never
+        /// silently changes input behavior. Has no effect when uGUI is not installed.
         /// </summary>
         public bool BlockWhenPointerOverUI
         {

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/Utils/InputWrapper.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/Scripts/Utils/InputWrapper.cs
@@ -74,6 +74,29 @@ namespace TransformHandles.Utils
         }
 
         /// <summary>
+        /// Pointer id of the primary active touch, for passing to
+        /// <c>EventSystem.IsPointerOverGameObject(int)</c>. Returns -1 when no touch is active
+        /// (-1 is the mouse/default pointer id, so the result also covers the mouse case).
+        /// Only meaningful while <see cref="HasActiveTouch"/> is true.
+        /// </summary>
+        public static int PrimaryTouchPointerId
+        {
+            get
+            {
+#if ENABLE_INPUT_SYSTEM && TH_INPUTSYSTEM
+                EnsureTouchInitialized();
+                if (Touch.activeTouches.Count > 0)
+                    return Touch.activeTouches[0].touchId;
+                return -1;
+#else
+                if (Input.touchCount > 0)
+                    return Input.GetTouch(0).fingerId;
+                return -1;
+#endif
+            }
+        }
+
+        /// <summary>
         /// Gets the current pointer position (mouse or touch) in screen coordinates.
         /// Prioritizes touch input on touch devices when a touch is active.
         /// </summary>

--- a/Packages/com.orkunmanap.runtime-transform-handles/Runtime/com.orkunmanap.runtime-transform-handles.asmdef
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Runtime/com.orkunmanap.runtime-transform-handles.asmdef
@@ -2,7 +2,8 @@
     "name": "com.orkunmanap.runtime-transform-handles",
     "rootNamespace": "TransformHandles",
     "references": [
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:2bafac87e7f4b9b418d9448d219b01ab"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -16,6 +17,11 @@
             "name": "com.unity.inputsystem",
             "expression": "1.0.0",
             "define": "TH_INPUTSYSTEM"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "1.0.0",
+            "define": "TH_UGUI"
         }
     ],
     "noEngineReferences": false

--- a/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/HandleDemo.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/HandleDemo.cs
@@ -192,7 +192,9 @@ public class HandleDemo : MonoBehaviour
     private void HandleSelectionInput()
     {
         if (_interacting) return; // don't pick targets mid-drag
-        if (PointerOverUi()) return; // clicks over the uGUI panel must not pick targets
+        // Respect the same toggle the handle manager uses, so flipping it off in the HUD lets
+        // both picking and handle drags pass through the panel (matching the on-screen hint).
+        if (_manager.BlockWhenPointerOverUI && PointerOverUi()) return;
 
         // Left click: select (Shift adds to the current handle's group).
         if (InputWrapper.GetMouseButtonDown(0) && TryPickTarget(out var picked))

--- a/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/HandleDemo.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/HandleDemo.cs
@@ -172,7 +172,10 @@ public class HandleDemo : MonoBehaviour
     {
 #if TH_UGUI
         var es = EventSystem.current;
-        return es != null && es.IsPointerOverGameObject();
+        if (es == null) return false;
+        if (es.IsPointerOverGameObject()) return true; // mouse / default pointer
+        // Also test the active finger so the guard works under touch (mouse-only otherwise).
+        return InputWrapper.HasActiveTouch && es.IsPointerOverGameObject(InputWrapper.PrimaryTouchPointerId);
 #else
         return false;
 #endif

--- a/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/HandleDemo.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/HandleDemo.cs
@@ -119,6 +119,9 @@ public class HandleDemo : MonoBehaviour
     private void BuildUiOcclusionOverlay()
     {
 #if TH_UGUI
+        // The guard is opt-in (off by default on the manager); turn it on here so the sample
+        // demonstrates it out of the box. Flip it from the HUD to compare on/off behavior.
+        _manager.BlockWhenPointerOverUI = true;
 #if UNITY_2023_1_OR_NEWER
         var hasEventSystem = Object.FindAnyObjectByType<EventSystem>() != null;
 #else

--- a/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/HandleDemo.cs
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/HandleDemo.cs
@@ -3,6 +3,10 @@ using System.Linq;
 using TransformHandles;
 using TransformHandles.Utils;
 using UnityEngine;
+#if TH_UGUI
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+#endif
 
 /// <summary>
 /// Self-contained showcase that exercises the whole public surface of the package:
@@ -105,6 +109,73 @@ public class HandleDemo : MonoBehaviour
             l.type = LightType.Directional;
             lightGo.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
         }
+
+        BuildUiOcclusionOverlay();
+    }
+
+    // Builds a real uGUI panel (+ an EventSystem if the scene lacks one) so the
+    // TransformHandleManager.BlockWhenPointerOverUI guard is demonstrable: with the guard on,
+    // clicking the panel must not select targets or start a handle drag underneath it.
+    private void BuildUiOcclusionOverlay()
+    {
+#if TH_UGUI
+#if UNITY_2023_1_OR_NEWER
+        var hasEventSystem = Object.FindAnyObjectByType<EventSystem>() != null;
+#else
+        var hasEventSystem = Object.FindObjectOfType<EventSystem>() != null;
+#endif
+        if (!hasEventSystem)
+        {
+            var esGo = new GameObject("EventSystem");
+            esGo.AddComponent<EventSystem>();
+#if ENABLE_INPUT_SYSTEM && TH_INPUTSYSTEM
+            esGo.AddComponent<UnityEngine.InputSystem.UI.InputSystemUIInputModule>().AssignDefaultActions();
+#else
+            esGo.AddComponent<StandaloneInputModule>();
+#endif
+        }
+
+        var canvasGo = new GameObject("Demo UI Canvas");
+        var canvas = canvasGo.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvasGo.AddComponent<CanvasScaler>();
+        canvasGo.AddComponent<GraphicRaycaster>();
+
+        var panelGo = new GameObject("UI Occlusion Test Panel");
+        panelGo.transform.SetParent(canvasGo.transform, false);
+        var panel = panelGo.AddComponent<Image>();
+        panel.color = new Color(0.15f, 0.45f, 0.85f, 0.85f); // raycast target by default
+        var rect = panel.rectTransform;
+        rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 1f);
+        rect.pivot = new Vector2(0.5f, 1f);
+        rect.sizeDelta = new Vector2(420f, 64f);
+        rect.anchoredPosition = new Vector2(0f, -12f);
+
+        var labelGo = new GameObject("Label");
+        labelGo.transform.SetParent(panelGo.transform, false);
+        var label = labelGo.AddComponent<Text>();
+        label.text = "uGUI panel — clicks here must NOT move objects\n(toggle the guard in the HUD)";
+        label.alignment = TextAnchor.MiddleCenter;
+        label.color = Color.white;
+        label.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf")
+                     ?? Resources.GetBuiltinResource<Font>("Arial.ttf");
+        var labelRect = label.rectTransform;
+        labelRect.anchorMin = Vector2.zero;
+        labelRect.anchorMax = Vector2.one;
+        labelRect.offsetMin = labelRect.offsetMax = Vector2.zero;
+#endif
+    }
+
+    // True while the pointer is over a uGUI element, so the demo's own target picking respects
+    // UI occlusion the same way the handle manager does. No-op without uGUI.
+    private bool PointerOverUi()
+    {
+#if TH_UGUI
+        var es = EventSystem.current;
+        return es != null && es.IsPointerOverGameObject();
+#else
+        return false;
+#endif
     }
 
     private void Update()
@@ -118,6 +189,7 @@ public class HandleDemo : MonoBehaviour
     private void HandleSelectionInput()
     {
         if (_interacting) return; // don't pick targets mid-drag
+        if (PointerOverUi()) return; // clicks over the uGUI panel must not pick targets
 
         // Left click: select (Shift adds to the current handle's group).
         if (InputWrapper.GetMouseButtonDown(0) && TryPickTarget(out var picked))
@@ -331,6 +403,10 @@ public class HandleDemo : MonoBehaviour
 
         var useSettings = GUILayout.Toggle(_useSettings, " Apply runtime Settings asset");
         if (useSettings != _useSettings) { _useSettings = useSettings; if (_useSettings && _activeHandle != null) _activeHandle.ApplySettings(_settings); }
+
+        var blockUi = GUILayout.Toggle(_manager.BlockWhenPointerOverUI, " Block interaction over UI");
+        if (blockUi != _manager.BlockWhenPointerOverUI) _manager.BlockWhenPointerOverUI = blockUi;
+        GUILayout.Label("<size=11>Click the blue panel (top): blocked when on, drags through when off.</size>");
 
         GUILayout.Space(6);
         GUILayout.BeginHorizontal();

--- a/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/TransformHandles.Samples.Demo.asmdef
+++ b/Packages/com.orkunmanap.runtime-transform-handles/Samples~/Demo/TransformHandles.Samples.Demo.asmdef
@@ -2,7 +2,9 @@
     "name": "TransformHandles.Samples.Demo",
     "rootNamespace": "",
     "references": [
-        "com.orkunmanap.runtime-transform-handles"
+        "com.orkunmanap.runtime-transform-handles",
+        "GUID:2bafac87e7f4b9b418d9448d219b01ab",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -11,6 +13,17 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.ugui",
+            "expression": "1.0.0",
+            "define": "TH_UGUI"
+        },
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "1.0.0",
+            "define": "TH_INPUTSYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ TransformHandleManager.Instance.Settings = mySettings;
 
 If no settings asset is assigned, the manager uses its serialized field values.
 
+### Blocking Interaction Over UI
+
+By default a handle interaction will not start while the pointer is over a uGUI element, so
+clicking a button or panel above the scene does not begin a drag (an in-progress interaction is
+never interrupted). Requires an `EventSystem` and the uGUI package; projects without uGUI are
+unaffected. Toggle in the Inspector or via code, and override `IsPointerOverUI()` for a non-uGUI
+UI stack:
+
+```csharp
+TransformHandleManager.Instance.BlockWhenPointerOverUI = false;
+```
+
 ## Default Keyboard Shortcuts
 
 | Key | Action |

--- a/README.md
+++ b/README.md
@@ -163,16 +163,17 @@ TransformHandleManager.Instance.Settings = mySettings;
 
 If no settings asset is assigned, the manager uses its serialized field values.
 
-### Blocking Interaction Over UI
+### Blocking Interaction Over UI (opt-in)
 
-By default a handle interaction will not start while the pointer is over a uGUI element, so
-clicking a button or panel above the scene does not begin a drag (an in-progress interaction is
-never interrupted). Requires an `EventSystem` and the uGUI package; projects without uGUI are
-unaffected. Toggle in the Inspector or via code, and override `IsPointerOverUI()` for a non-uGUI
-UI stack:
+Optionally, a handle interaction can be prevented from starting while the pointer is over a uGUI
+element, so clicking a button or panel above the scene does not begin a drag (an in-progress
+interaction is never interrupted; touch uses the active finger). It is **off by default** so it
+never silently changes input behavior. Requires an `EventSystem` and the uGUI package; projects
+without uGUI are unaffected. Enable in the Inspector or via code, and override `IsPointerOverUI()`
+for a non-uGUI UI stack:
 
 ```csharp
-TransformHandleManager.Instance.BlockWhenPointerOverUI = false;
+TransformHandleManager.Instance.BlockWhenPointerOverUI = true;
 ```
 
 ## Default Keyboard Shortcuts

--- a/ci/floor-2021/Packages/manifest.json
+++ b/ci/floor-2021/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.orkunmanap.runtime-transform-handles": "file:../../../Packages/com.orkunmanap.runtime-transform-handles",
     "com.unity.test-framework": "1.1.33",
+    "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",


### PR DESCRIPTION
## What

Clicking a uGUI element rendered above the scene no longer starts a handle drag — the most common integration papercut. An interaction already in progress is never interrupted (the guard only gates *starting* one).

- `TransformHandleManager.BlockWhenPointerOverUI` — serialized, default **on**, runtime-settable.
- `protected virtual bool IsPointerOverUI()` — override seam for non-uGUI UI stacks.

## Optional dependency, non-breaking

uGUI is wired as an **optional** dependency via the `TH_UGUI` version define, mirroring the existing Input System integration. Projects without `com.unity.ugui` compile cleanly and the guard is a no-op (`IsPointerOverUI` returns false). The `ci/floor-2021` project gains `com.unity.ugui` so the guarded path is compiled on the 2021.3 floor leg.

## Verification

Local batch (Unity 6000.3.16f1, uGUI present → `TH_UGUI` path): EditMode **62/62**, PlayMode **35/35**, zero compiler warnings. Interaction suite confirms drag-start still works when no `EventSystem` is present (guard inert). The occlusion itself depends on live pointer state, which Unity cannot reproduce headless — manual verification: a fullscreen Canvas button over the scene must not start a drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-off behavior preserves existing input; risk is limited to projects that enable the flag and rely on EventSystem/uGUI pointer hits (including touch pointer id).
> 
> **Overview**
> Adds an **opt-in** guard so transform-handle drags do not **start** while the pointer is over uGUI (`TransformHandleManager.BlockWhenPointerOverUI`, **off by default**). When enabled and not dragging, hover raycasts are skipped over UI, which clears highlight and blocks `MouseInput` from beginning a drag; active drags are unchanged.
> 
> uGUI is optional via the `TH_UGUI` version define (asmdef reference + `versionDefines`); without uGUI the guard is a no-op. `protected virtual IsPointerOverUI()` supports custom UI stacks. `InputWrapper.PrimaryTouchPointerId` lets touch use `EventSystem.IsPointerOverGameObject(int)`.
> 
> The Demo sample spawns an overlay panel, ensures an `EventSystem`, mirrors the guard for target picking, and adds a HUD toggle. README/changelog document the feature; `ci/floor-2021` adds `com.unity.ugui` so the guarded code path compiles on the 2021.3 floor job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6159cbdb50282b075e8e6f2ebe238d076621e93c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->